### PR TITLE
Feature/mw 97 dashboard internationalization

### DIFF
--- a/app/views/dashboard/_offered_items.html.erb
+++ b/app/views/dashboard/_offered_items.html.erb
@@ -31,7 +31,7 @@
 <div>
   <% items = Item.where(owner: current_user).order("name ASC") %>
   <% if items.empty? %>
-    <p class="body1">Du bietest bisher nichts an.</p>
+    <p class="body1"><%= t 'views.dashboard.nothing_offered' %></p>
   <% else %>
     <div class="container text-center">
       <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5 align-items-end justify-content-start">

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -35,20 +35,20 @@
 </style>
 
 <% if user_signed_in? %>
-  <p class="title">Hallo <%= @user.first_name %>!</p>
+  <p class="title"><%= t('views.dashboard.greeting', name: @user.first_name)%></p>
 
 
-  <h3 class="subtitle box">Du hast ... ungelesene Nachrichten</h3>
+  <h3 class="subtitle box"><%= t 'views.dashboard.unread_messages' %></h3>
 
-  <h3 class="subtitle">AUSGELIEHEN</h3>
+  <h3 class="subtitle"><%= t 'views.dashboard.lent_items' %></h3>
   <div class="feature-icon mb-1">
     <i class="bi bi-chat-square-quote-fill" style="font-size: 2rem;"></i>
   </div>
 
-  <h3 class="subtitle">ANGEBOTENE ARTIKEL</h3>
+  <h3 class="subtitle"><%= t 'views.dashboard.offered_items' %></h3>
   <%= render "offered_items"%>
 
-  <h3 class=" subtitle place-holder-nav">DEINE WUNSCHLISTE</h3>
+  <h3 class=" subtitle place-holder-nav"><%= t 'views.dashboard.your_wishlist' %></h3>
   <div class="feature-icon mb-1">
     <i class="bi bi-chat-square-quote-fill" style="font-size: 2rem;"></i>
   </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -54,7 +54,7 @@
   </div>
 
 <% else %>
-  <p class="lead mb-4">Du bist nicht angemeldet. </p>
+  <p class="lead mb-4"><%= t 'views.dashboard.not_signed_in' %></p>
   <%= link_to new_user_session_path, { class: "btn btn-primary btn-lg px-4" } do %>
     <i class="bi bi-box-arrow-in-right"></i> <%= t 'views.landing_page.login' %>
   <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -12,6 +12,12 @@ de:
       edit_btn: "Profil bearbeiten"
     dashboard:
       title: "Übersicht"
+      greeting: "Hallo, %{name}!"
+      unread_messages: "Du hast ... ungelesene Nachrichten"
+      lent_items: "AUSGELIEHENE ARTIKEL"
+      offered_items: "ANGEBOTENE ARTIKEL"
+      nothing_offered: "Du bietest bisher nichts an."
+      your_wishlist: "DEINE WUNSCHLISTE"
     notifications:
       title: "Benachrichtigungen"
     search:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -18,6 +18,7 @@ de:
       offered_items: "ANGEBOTENE ARTIKEL"
       nothing_offered: "Du bietest bisher nichts an."
       your_wishlist: "DEINE WUNSCHLISTE"
+      not_signed_in: "Du bist nicht angemeldet."
     notifications:
       title: "Benachrichtigungen"
     search:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,7 @@ en:
       offered_items: "OFFERED ITEMS"
       nothing_offered: "You do not offer any items at the moment."
       your_wishlist: "YOUR WISHLIST"
+      not_signed_in: "You are not signed in."
     notifications:
       title: "Notifications"
     search:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,12 @@ en:
       edit_btn: "Edit user profile"
     dashboard:
       title: "Dashboard"
+      greeting: "Hello, %{name}!"
+      unread_messages: "You have ... unread messages"
+      lent_items: "LENT ITEMS"
+      offered_items: "OFFERED ITEMS"
+      nothing_offered: "You do not offer any items at the moment."
+      your_wishlist: "YOUR WISHLIST"
     notifications:
       title: "Notifications"
     search:

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -19,26 +19,26 @@ RSpec.describe "Dashboard", type: :feature do
   it "shows unread messages" do
     sign_in user
     visit dashboard_path
-    expect(page).to have_content(/ungelesene Nachrichten/i)
+    expect(page).to have_content I18n.t('views.dashboard.unread_messages')
   end
 
-  it "shows borrowed items" do
+  it "shows lent items" do
     sign_in user
     visit dashboard_path
-    expect(page).to have_content(/ausgeliehen/i)
+    expect(page).to have_content I18n.t('views.dashboard.lent_items')
   end
 
-  it "shows offered messages" do
+  it "shows offered items" do
     sign_in user
     visit dashboard_path
-    expect(page).to have_content(/angebotene Artikel/i)
+    expect(page).to have_content I18n.t('views.dashboard.offered_items')
   end
 
   it "shows message when nothing is offered" do
     @user = create(:user)
     sign_in @user
     visit dashboard_path
-    expect(page).to have_content("Du bietest bisher nichts an.")
+    expect(page).to have_content I18n.t('views.dashboard.nothing_offered')
   end
 
   it "shows offered item" do
@@ -52,6 +52,6 @@ RSpec.describe "Dashboard", type: :feature do
   it "shows wishlist" do
     sign_in user
     visit dashboard_path
-    expect(page).to have_content(/Wunschliste/i)
+    expect(page).to have_content I18n.t('views.dashboard.your_wishlist')
   end
 end

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Dashboard", type: :feature do
 
   it "renders without user signed in" do
     visit dashboard_path
-    expect(page).to have_content("Du bist nicht angemeldet.")
+    expect(page).to have_content I18n.t('views.dashboard.not_signed_in')
   end
 
   it "shows the user name" do


### PR DESCRIPTION
Fixes #97

Adds internationalization to the Dashboard.
![Screenshot Dashboard Deutsch](https://user-images.githubusercontent.com/68274879/206173294-80fcd3a3-491c-4b44-bd9f-65df650196cf.png)
![Screenshot Dashboard Englisch](https://user-images.githubusercontent.com/68274879/206173372-3b02fd32-98a6-4915-bb7b-409ef181aedd.png)
![Screenshot 2022-12-09 at 19-04-52 Bookkeeper Blue](https://user-images.githubusercontent.com/82374600/206765136-f7ba59af-a80d-42e8-9076-48f00517df56.png)
![Screenshot 2022-12-09 at 19-04-28 Bookkeeper Blau](https://user-images.githubusercontent.com/82374600/206765145-58d80280-88f5-48a0-8f71-812266d9c6c7.png)


## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [ ] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
