### PR TITLE
Fix: lint error

### DIFF
--- a/spec/features/search/search_spec.rb
+++ b/spec/features/search/search_spec.rb
@@ -1,6 +1,13 @@
 require "rails_helper"
 
 describe "Search page", type: :feature do
+  before do
+    @item_book = create(:item_book)
+    @item_beamer = create(:item_beamer)
+    @item_whiteboard = create(:item_whiteboard)
+    visit search_path
+  end
+
   it "translates the close button to German" do
     page.driver.header 'Accept-language', 'de-DE'
     visit search_path
@@ -10,13 +17,6 @@ describe "Search page", type: :feature do
   it "translates the close button to English by default" do
     visit search_path
     expect(page).to have_text("Close")
-  end
-
-  before do
-    @item_book = create(:item_book)
-    @item_beamer = create(:item_beamer)
-    @item_whiteboard = create(:item_whiteboard)
-    visit search_path
   end
 
   it "partial matching works for title" do


### PR DESCRIPTION
This PR fixes the linting erros of `spec/features/search/search_spec.rb`.

## PR checklist

- [ ] dev-branch has been merged into local branch to resolve conflicts
- [ ] tests and linter have passed AFTER local merge
- [ ] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [ ] another dev reviewed and approved
- [ ] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
