### PR TITLE
FIX/BR #177 changed link on item view to :back

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -113,7 +113,7 @@
 </style>
 <div>
  
-  <%= link_to items_url do %>
+  <%= link_to :back do %>
     <span class="material-symbols-outlined" id="back-button">chevron_left</span>
   <% end %>
   <% if (!current_user.nil? && @item.owner == current_user.id) %>


### PR DESCRIPTION
Fixes #177

This wasn't really a bug, the specification just changed.

this changes the "back-button" link on the item-view page to actually go back instead of going to /items

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] another dev reviewed and approved
