### PR TITLE
Fix/pbrh+ 183 bug cant display items

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,6 +9,11 @@ class ItemsController < ApplicationController
 
   # GET /items/1 or /items/1.json
   def show
+    @item = Item.find(params[:id])
+    if @item.waitlist.nil?
+      @item.waitlist = Waitlist.new
+      @item.save
+    end
   end
 
   # GET /items/new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,10 +10,10 @@ class ItemsController < ApplicationController
   # GET /items/1 or /items/1.json
   def show
     @item = Item.find(params[:id])
-    if @item.waitlist.nil?
-      @item.waitlist = Waitlist.new
-      @item.save
-    end
+    return unless @item.waitlist.nil?
+
+    @item.waitlist = Waitlist.new
+    @item.save
   end
 
   # GET /items/new


### PR DESCRIPTION
Fixes #183

Opening the item view did cause an error for items, which were created before waitlists were introduced to the system. This is a temporary fix for this issue, to ensure the PO presentation can take place, without recreating all items.

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [x] another dev reviewed and approved
