### PR TITLE
Feature/ap 140 empty search string behavoir

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,6 +1,12 @@
 class SearchController < ApplicationController
   def index
     search_term = params[:search]
+    if search_term.blank?
+      @lastsearch = params[:lastsearch]
+      search_term = @lastsearch
+    else
+      @lastsearch = search_term
+    end
     @results = helpers.search_for_items(search_term)
   end
 end

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -38,6 +38,7 @@
             </div>
         </div>
     </div>
+    <%= text_field_tag :lastsearch, params[:lastsearch], class: "form-control invisible", value: @lastsearch %>
 <% end %>
 
 <% if @results %>

--- a/spec/features/search/search_spec.rb
+++ b/spec/features/search/search_spec.rb
@@ -51,4 +51,14 @@ describe "Search page", type: :feature do
     expect(page).not_to have_text(@item_whiteboard.name)
   end
 
+  it "shows last search result when searching for nothing after searching for something" do
+    page.fill_in "search", with: "book"
+    click_button("submit")
+    page.fill_in "search", with: ""
+    click_button("submit")
+    expect(page).to have_text(@item_book.name)
+    expect(page).not_to have_text(@item_beamer.name)
+    expect(page).not_to have_text(@item_whiteboard.name)
+  end
+
 end


### PR DESCRIPTION
Fixes #140 

We've added a hidden text field to save the last search string. If the new search string is empty, we use the information from this field.

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)

https://user-images.githubusercontent.com/45163503/208063212-53c74f18-70d9-4382-a972-6425821312de.mov