### PR TITLE
Feature/pbrh+ 27 adaptive lendbutton

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -88,7 +88,9 @@ class ItemsController < ApplicationController
     @notification = LendRequestNotification.find_by(item: @item)
     @item.set_status_lent
     @item.holder = @notification.borrower.id
+    @notification.destroy
     @item.save
+    redirect_to item_url(@item)
   end
 
   def request_return

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -75,23 +75,11 @@ class ItemsController < ApplicationController
   def request_lend
     @item = Item.find(params[:id])
     @user = current_user
-    @item.holder = @user.id
-    @item.set_status_lent
+    @owner = User.find(@item.owner)
+    @notification = LendRequestNotification.new(item: @item, borrower: @user, user: @owner, date: Time.zone.now)
+    @notification.save
+    @item.set_status_pending_lend_request
     @item.save
-
-    redirect_to item_url(@item)
-  end
-
-  def request_return
-    @item = Item.find(params[:id])
-    @item.request_return
-    @item.save
-    @user = current_user
-    unless ReturnRequestNotification.find_by(item: @item)
-      @notification = ReturnRequestNotification.new(user: User.find(@item.owner), date: Time.zone.now, item: @item,
-                                                    borrower: @user)
-      @notification.save
-    end
     redirect_to item_url(@item)
   end
 
@@ -103,12 +91,28 @@ class ItemsController < ApplicationController
     @item.save
   end
 
+  def request_return
+    @item = Item.find(params[:id])
+    @item.set_status_pending_return
+    @item.save
+    @user = current_user
+    unless ReturnRequestNotification.find_by(item: @item)
+      @notification = ReturnRequestNotification.new(user: User.find(@item.owner),
+                                                    date: Time.zone.now, item: @item, borrower: @user)
+      @notification.save
+    end
+    redirect_to item_url(@item)
+  end
+
   def accept_return
     @item = Item.find(params[:id])
     @notification = ReturnRequestNotification.find_by(item: @item)
     @notification.destroy
     # TODO: Send return accepted notification to borrower
-    @item.accept_return
+    @item.rental_start = nil
+    @item.rental_duration_sec = nil
+    @item.holder = nil
+    @item.set_status_available
     @item.save
     redirect_to item_url(@item)
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,7 +11,8 @@ class Item < ApplicationRecord
   validates :description, presence: true
   validates :owner, presence: true
   validates :price_ct, numericality: { allow_nil: true, greater_than_or_equal_to: 0 }
-  enum :lend_status, { available: 0, lent: 1, pending_return: 2 }
+  enum :lend_status,
+       { available: 0, lent: 1, pending_return: 2, pending_lend_request: 3, pending_pickup: 4, unavailable: 5 }
   validates :lend_status, presence: true, inclusion: { in: lend_statuses.keys }
 
   def price_in_euro
@@ -20,28 +21,35 @@ class Item < ApplicationRecord
       euro = (price_ct - ct) / 100
       return euro, ct
     end
-
     [0, 0]
   end
 
-  def request_return
-    # TODO: send request return notification to owner with holder information
-    self.lend_status = :pending_return
-  end
-
-  def accept_return
-    self.rental_start = nil
-    self.rental_duration_sec = nil
-    self.holder = nil
+  def set_status_available
     self.lend_status = :available
   end
 
-  def deny_return
-    # TODO
+  def set_status_pending_lend_request
+    self.lend_status = :pending_lend_request
   end
 
   def set_status_lent
     self.lend_status = :lent
+  end
+
+  def set_status_pending_return
+    self.lend_status = :pending_return
+  end
+
+  def set_status_pending_pickup
+    self.lend_status = :pending_pickup
+  end
+
+  def set_status_unavailable
+    self.lend_status = :unavailable
+  end
+
+  def deny_return
+    self.lend_status = :unavailable
   end
 
   def price_in_euro=(euros)

--- a/app/views/items/_adaptive_lend_button.html.erb
+++ b/app/views/items/_adaptive_lend_button.html.erb
@@ -1,11 +1,19 @@
 
 <% if !current_user.nil? && current_user.id != item.owner %>
     <% if item.holder == current_user.id %>
-        <%= button_to t('views.show_item.return'), { action: "request_return" }, class: "primaryButton" %>
+        <% if item.lend_status == "pending_return" %>
+            <%= button_to t('views.show_item.pending_return_request'), { }, class: "secondaryButton", disabled: true %>
+        <% else %>
+            <%= button_to t('views.show_item.return'), { action: "request_return" }, class: "primaryButton" %>
+        <% end %>
     <% elsif item.lend_status == "available" %>
         <%= button_to t('views.show_item.lend'), { action: "request_lend" }, class: "primaryButton" %>
     <% elsif !item.waitlist.users.exists?(current_user.id) %>
-        <%= button_to t('views.show_item.enter_waitlist'), { action: "add_to_waitlist" }, class: "primaryButton" %>
+        <% if item.lend_status == "pending_lend_request" && !LendRequestNotification.find_by(user: item.owner, item: item, borrower: current_user).nil? %>
+            <%= button_to t('views.show_item.pending_lend_request'), { }, class: "secondaryButton", disabled: true %>
+        <% else %>
+            <%= button_to t('views.show_item.enter_waitlist'), { action: "add_to_waitlist" }, class: "primaryButton" %>
+        <% end %>
     <% else %>
         <%= button_to t('views.show_item.leave_waitlist'), { action: "leave_waitlist" }, class: "primaryButton" %>
     <% end %>

--- a/app/views/items/_adaptive_lend_button.html.erb
+++ b/app/views/items/_adaptive_lend_button.html.erb
@@ -1,0 +1,12 @@
+
+<% if !current_user.nil? && current_user.id != item.owner %>
+    <% if item.holder == current_user.id %>
+        <%= button_to t('views.show_item.return'), { action: "request_return" }, class: "primaryButton" %>
+    <% elsif item.lend_status == "available" %>
+        <%= button_to t('views.show_item.lend'), { action: "request_lend" }, class: "primaryButton" %>
+    <% elsif !item.waitlist.users.exists?(current_user.id) %>
+        <%= button_to t('views.show_item.enter_waitlist'), { action: "add_to_waitlist" }, class: "primaryButton" %>
+    <% else %>
+        <%= button_to t('views.show_item.leave_waitlist'), { action: "leave_waitlist" }, class: "primaryButton" %>
+    <% end %>
+<% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -154,25 +154,11 @@
           <% if !@item.waitlist.users.exists?(current_user.id) %>
             <%= t('views.show_item.users_waiting', amount: @item.waitlist.users.size) %>
           <% else %>
-            <%= t('views.show_item.waitlist_position', position: @item.waitlist.users.find_index(current_user) + 1) %>      
+            <%= t('views.show_item.waitlist_position', position: @item.waitlist.users.find_index(current_user) + 1) %>
           <% end %>
         <% end %>
       </p>
-      <% if !current_user.nil? && current_user.id != @item.owner %>
-        <% if @item.holder == current_user.id %>
-          <%= button_to t('views.show_item.return'), { action: "request_return" }, class: "primaryButton" %>
-        <% else %>
-          <% if @item.lend_status == "available" %>
-            <%= button_to t('views.show_item.lend'), { action: "request_lend" }, class: "primaryButton" %>
-          <% else %>
-            <% if !@item.waitlist.users.exists?(current_user.id) %>
-              <%= button_to t('views.show_item.enter_waitlist'), { action: "add_to_waitlist" }, class: "primaryButton" %>
-            <% else %>
-              <%= button_to t('views.show_item.leave_waitlist'), { action: "leave_waitlist" }, class: "primaryButton" %>
-            <% end %>
-          <% end %>
-        <% end %>
-      <% end %>
+      <%= render "adaptive_lend_button", current_user: current_user, item: @item %>
       <br><br><br>
     </div>
   </div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -9,9 +9,13 @@
     <% notifications.each do |notification|%>
       <div class="container notification">
         <div class="row ">          
-          <div class="col align-self-center">
+          <div class="col-sm-1 align-self-center">
             <%= render_if_exists notification.custom_partial, notification: notification %>
-          </div>          
+          </div>
+          <div class="col-sm-11 align-self-center">
+            <h3> <%= notification.title %> </h3>
+            <p> <%= notification.description %> </p>
+          </div>
         </div>
       </div>
     <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -65,6 +65,8 @@ de:
       waitlist_position: "Sie stehen an Position %{position} der Warteliste."
       lend: "Ausleihen"
       return: "Zurückgeben"
+      pending_lend_request: "Warten auf Ausleihbestätigung"
+      pending_return_request: "Warten auf Rückgabebestätigung"
     edit_item:
       rental_duration_sec: "Ausleihdauer (Sekunden)"
     profile:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,8 @@ en:
       waitlist_position: "You are at Position %{position} of the Waitlist."
       lend: "Lend"
       return: "Return"
+      pending_lend_request: "Waiting for lend approval"
+      pending_return_request: "Waiting for return approval"
     edit_item:
       rental_duration_sec: "Rental Duration (seconds)"
     profile:

--- a/spec/features/items/show.html.erb_spec.rb
+++ b/spec/features/items/show.html.erb_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "items/show", type: :feature do
   it "has enter waitlist button when not on list and item not available" do
     sign_in user
     visit item_path(item_lent)
-    expect(page).to have_text("Enter Waitlist")
+    expect(page).to have_button("Enter Waitlist")
   end
 
   it "does not have an adaptive lend button when owner of item" do
@@ -65,7 +65,7 @@ RSpec.describe "items/show", type: :feature do
     sign_in user
     item_lent.waitlist.add_user(user)
     visit item_path(item_lent)
-    expect(page).to have_text("Leave Waitlist")
+    expect(page).to have_button("Leave Waitlist")
   end
 
   it "adds user to waitlist when clicking add to waitlist button" do

--- a/spec/features/items/show.html.erb_spec.rb
+++ b/spec/features/items/show.html.erb_spec.rb
@@ -50,11 +50,15 @@ RSpec.describe "items/show", type: :feature do
     expect(page).to have_text("Enter Waitlist")
   end
 
-  it "does not have enter/leave waitlist button when owner of item" do
+  it "does not have an adaptive lend button when owner of item" do
     sign_in owner
     visit item_path(item)
-    expect(page).not_to have_text("Enter Waitlist")
-    expect(page).not_to have_text("Leave Waitlist")
+    expect(page).not_to have_button("Lend")
+    expect(page).not_to have_button("Waiting for lend approval")
+    expect(page).not_to have_button("Return")
+    expect(page).not_to have_button("Waiting for return approval")
+    expect(page).not_to have_button("Enter Waitlist")
+    expect(page).not_to have_button("Leave Waitlist")
   end
 
   it "has leave waitlist button when on list" do

--- a/spec/features/notifications/lend_request_notification_spec.rb
+++ b/spec/features/notifications/lend_request_notification_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 describe "Return Request Notifications", type: :feature do
 
   it "user gets notified someone wants to lend his/her item" do
-    owner = FactoryBot.create(:max)
-    borrower = FactoryBot.create(:peter)
-    item = FactoryBot.create(:item, owner: owner.id)
-    sign_in borrower   
-    visit item_path(item)   
+    owner = create(:max)
+    borrower = create(:peter)
+    item = create(:item, owner: owner.id)
+    sign_in borrower
+    visit item_path(item)
     click_button('Lend')
     sign_in owner
     visit notifications_path

--- a/spec/features/notifications/lend_request_notification_spec.rb
+++ b/spec/features/notifications/lend_request_notification_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe "Return Request Notifications", type: :feature do
+
+  it "user gets notified someone wants to lend his/her item" do
+    owner = FactoryBot.create(:max)
+    borrower = FactoryBot.create(:peter)
+    item = FactoryBot.create(:item, owner: owner.id)
+    sign_in borrower   
+    visit item_path(item)   
+    click_button('Lend')
+    sign_in owner
+    visit notifications_path
+    expect(page).to have_text(borrower.name)
+    expect(page).to have_text(item.name)
+  end
+end

--- a/spec/features/notifications/return_request_notifications_spec.rb
+++ b/spec/features/notifications/return_request_notifications_spec.rb
@@ -32,6 +32,7 @@ describe "Return Request Notifications", type: :feature do
   it "deletes the notification upon clicking on 'Decline" do
     visit notifications_path
     expect(ReturnRequestNotification.exists?(@notification.id)).to be true
+    click_button('Check')
     click_button('Decline')
     expect(ReturnRequestNotification.exists?(@notification.id)).to be false
   end

--- a/spec/models/lend_request_notification_spec.rb
+++ b/spec/models/lend_request_notification_spec.rb
@@ -26,5 +26,4 @@ RSpec.describe LendRequestNotification, type: :model do
       expect(notification.description).not_to eq description
     end
   end
-
 end


### PR DESCRIPTION
Fixes #27

Description

Add in-between stages of the adaptive lend button:
- _Waiting for lend approval_
- _Waiting for return approval_

These other stages were already on `dev` and `feature/pbrh+-12-lend-request` (#12) (which we merged into our branch):
- _Lend_
- _Return_
- _Enter Waitlist_
- _Leave Waitlist_

Also fixes a problem with lend request notifications not being deleted after approval.

Demo:

[adaptive_lend_button.webm](https://user-images.githubusercontent.com/41512063/208121809-0657ee63-a7d8-46bb-b377-59a24427ec76.webm)

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [x] another dev reviewed and approved
- [ ] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
