### PR TITLE
Fixed Bug with item without image in notification

### DIFF
--- a/app/views/notifications/_lend_request_notification.html.erb
+++ b/app/views/notifications/_lend_request_notification.html.erb
@@ -61,9 +61,11 @@
         <%end%>
         <p>
           <%= notification.description %>
+          <% if notification.item.image.attached? %>
           <div class="col-md-4">
               <%= image_tag notification.item.image, class: "img-responsive rounded mx-auto d-block", style: "max-width: 13em" %>
           </div>
+          <% end %>
         </p>
       </div>
       


### PR DESCRIPTION
Fixes #<n>

There was a bug where a item without image caused a crash due to missing check 

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
