### PR TITLE
Description of an item can be empty

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,7 +13,6 @@ class Item < ApplicationRecord
   validates :name, presence: true
   validates :category, presence: true
   validates :location, presence: true
-  #validates :description, allow_blank: true
   validates :owner, presence: true
   validates :price_ct, numericality: { allow_nil: true, greater_than_or_equal_to: 0 }
   validates :rental_duration_sec, numericality: { allow_nil: true, greater_than_or_equal_to: 0 }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,7 +13,7 @@ class Item < ApplicationRecord
   validates :name, presence: true
   validates :category, presence: true
   validates :location, presence: true
-  validates :description, presence: true
+  #validates :description, allow_blank: true
   validates :owner, presence: true
   validates :price_ct, numericality: { allow_nil: true, greater_than_or_equal_to: 0 }
   validates :rental_duration_sec, numericality: { allow_nil: true, greater_than_or_equal_to: 0 }

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -146,12 +146,10 @@
       </div>
       <p class="subtitle"><%= t('views.show_item.category')%></p>
       <p class="body-1"><%= @item.category %></p>
-      <p class="subtitle">
-        <% if !@item.description.blank? %>
-          <%= t('views.show_item.description')%>
-          <p class="body-1"><%= @item.description %></p>
-        <% end %>
-      </p>
+      <% if !@item.description.blank? %>
+      <p class="subtitle"><%= t('views.show_item.description')%></p>
+        <p class="body-1"><%= @item.description %></p>
+      <% end %>
       <p class="subtitle"><%= t('views.show_item.owner')%></p>
       <p class="body-1"><%= User.find(@item.owner).email %></p>
       <p class="subtitle"><%= t('views.show_item.lend_until')%></p>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -146,8 +146,12 @@
       </div>
       <p class="subtitle"><%= t('views.show_item.category')%></p>
       <p class="body-1"><%= @item.category %></p>
-      <p class="subtitle"><%= t('views.show_item.description')%></p>
-      <p class="body-1"><%= @item.description %></p>
+      <p class="subtitle">
+        <% if !@item.description.blank? %>
+          <%= t('views.show_item.description')%>
+          <p class="body-1"><%= @item.description %></p>
+        <% end %>
+      </p>
       <p class="subtitle"><%= t('views.show_item.owner')%></p>
       <p class="body-1"><%= User.find(@item.owner).email %></p>
       <p class="subtitle"><%= t('views.show_item.lend_until')%></p>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,8 +14,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_180533) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_180533) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe Item, type: :model do
     expect(item).not_to be_valid
   end
 
-  it "is not valid without description" do
+  it "is valid without description" do
     item = described_class.new(name: "Test", category: "Test", location: "Test", owner: @user.id)
-    expect(item).not_to be_valid
+    expect(item).to be_valid
   end
 
   it "is not valid with negative price" do


### PR DESCRIPTION
- create an item with an empty description is now possible 
- headline "description" is not shown when description is empty

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
