### PR TITLE
increase width of all item views

### DIFF
--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -87,28 +87,6 @@
       'opsz' 48
   }
 
-  @media screen and (min-width: 768px) {
-    .image{
-      position:relative;
-      overflow:hidden;
-      padding-bottom:20em;
-      width: 23em;
-      height: 23em !important;
-      padding-left: 0px;
-      padding-right: 0px;   
-    }
-    .image img{
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translateX(-50%) translateY(-50%);
-      border-radius: 5px;
-    }
-    .centeredContainer{
-      margin: 0 auto;
-      width: 25em;
-    }
-  }
   .notBorderedInput {
     width: 100%;
     margin-bottom: 8px
@@ -138,52 +116,60 @@
 
 <div>
 <%= form_with(model: @item) do |form| %>
-  <div class="row">
-    <div class="centeredContainer">
-          <div class="text-center">
 
-  <% if @item.errors.any? %>
-    <div style="color: red">
-      <h2><%= pluralize(@item.errors.count, "error") %> prohibited this item from being saved:</h2>
+  
 
-      <ul>
-        <% @item.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
+    <% if @item.errors.any? %>
+      <div style="color: red">
+        <h2><%= pluralize(@item.errors.count, "error") %> prohibited this item from being saved:</h2>
+
+        <ul>
+          <% @item.errors.each do |error| %>
+            <li><%= error.full_message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="container">
+      <div class="row row-cols-1 row-cols-md-2">
+        <div class="text-center col">
+
+
+          <div class="image container-fluid rounded">
+            <%= image_tag @item.image, class: "img img-responsive img-fluid rounded mx-auto d-block" if @item.image.attached? %>
+          </div>
+
+          <%= form.file_field :image, class: "notBorderedInput" %>
+        </div>
+
+        <div class="col">
+          <div>
+          <p class="title">
+            <%= form.text_field :name, class: "borderedInput" %>
+          </p>
+          </div>
+          <div class="row">
+            <p class="body-1" id="location">
+              <span class="material-symbols-outlined" id="locationIcon">location_on</span>
+              <%= form.text_field :location, class: "locationInput borderedInput" %>
+            </p>
+          </div>
+          
+            <p class="subtitle"><%= t('views.show_item.category')%></p>
+            <%= form.text_field :category, class: "borderedInput body1" %>
+            <p class="subtitle"><%= t('views.show_item.description')%></p>
+            <%= form.text_area :description, class: "borderedInput body1" %>
+            <p class="subtitle"><%= t('views.show_item.owner')%></p>
+            <div class="notBorderedInput">
+            <%= form.collection_select(:owner, User.all, :id, :email, :include_blank => true)%>
+            </div>
+            <p class="subtitle"><%= t('views.edit_item.rental_duration_sec')%></p>
+            <%= form.number_field :rental_duration_sec, class: "borderedInput body1" %>    
+            <%= form.submit class: "btn-primary" %>
+          </div>
+        </div>
     </div>
-  <% end %>
-
-  <div class="image container-fluid rounded">
-    <%= image_tag @item.image, class: "img img-responsive img-fluid rounded mx-auto d-block" if @item.image.attached? %>
-  </div>
-
-  <%= form.file_field :image, class: "notBorderedInput" %>
- 
-  <div>
-  <p class="title">
-    <%= form.text_field :name, class: "borderedInput" %>
-  </p>
-  </div>
-  <div class="row">
-    <p class="body-1" id="location">
-      <span class="material-symbols-outlined" id="locationIcon">location_on</span>
-      <%= form.text_field :location, class: "locationInput borderedInput" %>
-    </p>
-  </div>
-  </div>
-    <p class="subtitle"><%= t('views.show_item.category')%></p>
-    <%= form.text_field :category, class: "borderedInput body1" %>
-    <p class="subtitle"><%= t('views.show_item.description')%></p>
-    <%= form.text_area :description, class: "borderedInput body1" %>
-    <p class="subtitle"><%= t('views.show_item.owner')%></p>
-    <div class="notBorderedInput">
-    <%= form.collection_select(:owner, User.all, :id, :email, :include_blank => true)%>
-    </div>
-    <p class="subtitle"><%= t('views.edit_item.rental_duration_sec')%></p>
-    <%= form.number_field :rental_duration_sec, class: "borderedInput body1" %>    
-    <%= form.submit class: "btn-primary" %>
-  </div>
-  </div>
+ </div>
 <% end %>
 </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -73,33 +73,6 @@
      color: var(--grey09);
   }
 
-  @media screen and (min-width: 768px) {
-    .image{
-      position:relative;
-      overflow:hidden;
-      padding-bottom:20em;
-      width: 23em;
-      height: 23em !important;
-      padding-left: 0px;
-      padding-right: 0px;   
-    }
-    .image img{
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translateX(-50%) translateY(-50%);
-      border-radius: 5px;
-    }
-    .centeredContainer{
-      margin: 0 auto;
-      width: 25em;
-    }
-    #imagePlaceholder {
-    background-color: var(--grey11);
-    width: 23em;
-    height: 23em !important;
-  }
-  }
   .notBorderedInput {
     width: 100%;
     margin-bottom: 8px
@@ -156,9 +129,6 @@ function readURL(input) {
 </script>
 <div>
 <%= form_with(model: @item, :html => {:multipart => true}) do |form| %>
-  <div class="row">
-    <div class="centeredContainer">
-          <div class="text-center">
 
   <% if @item.errors.any? %>
     <div style="color: red">
@@ -172,60 +142,67 @@ function readURL(input) {
     </div>
   <% end %>
 
-  <div class="image container-fluid rounded">
-    <img id="img_prev" class="img img-responsive img-fluid rounded mx-auto d-flex align-items-center justify-content-center" src="#" alt=""/>
-    <div class="img img-responsive img-fluid rounded mx-auto d-flex align-items-center justify-content-center" id=imagePlaceholder>
-      <span class="material-symbols-outlined" id="imageIcon">image</span>
-    </div> 
-  </div>
+  <div class="container">
+    <div class="row row-cols-1 row-cols-md-2">
+      <div class="text-center col">
 
-  <%= form.file_field :image, multiple: false, direct_upload: true, :onchange => "readURL(this)"%>  
+        <div class="image container-fluid rounded">
+          <img id="img_prev" class="img img-responsive img-fluid rounded mx-auto d-flex align-items-center justify-content-center" src="#" alt=""/>
+          <div class="img img-responsive img-fluid rounded mx-auto d-flex align-items-center justify-content-center" id=imagePlaceholder>
+            <span class="material-symbols-outlined" id="imageIcon">image</span>
+          </div> 
+        </div>
+
+        <%= form.file_field :image, multiple: false, direct_upload: true, :onchange => "readURL(this)"%>
+
+      </div>  
 
 
-  <div>
-  <p class="title">
-    <%= form.text_field :name, class: "borderedInput", placeholder: t('views.new_item.item_name') %>
-  </p>
-  </div>
-  <div class="row">
-    <p class="body1" id="location">
-      <span class="material-symbols-outlined" id="locationIcon">location_on</span>
-      <%= form.text_field :location, class: "locationInput borderedInput", placeholder: t('views.new_item.location') %>
-    </p>
-  </div>
-  </div>
-    <p class="subtitle"><%= t('views.show_item.category')%></p>
-    <%= form.text_field :category, class: "borderedInput body1" %>
+      <div class="col">
+        <div>
+          <p class="title">
+            <%= form.text_field :name, class: "borderedInput", placeholder: t('views.new_item.item_name') %>
+          </p>
+          <div class="row">
+            <p class="body1" id="location">
+              <span class="material-symbols-outlined" id="locationIcon">location_on</span>
+              <%= form.text_field :location, class: "locationInput borderedInput", placeholder: t('views.new_item.location') %>
+            </p>
+        </div>
+      
+        <p class="subtitle"><%= t('views.show_item.category')%></p>
+        <%= form.text_field :category, class: "borderedInput body1" %>
 
-    <p class="subtitle"><%= t('views.show_item.description')%></p>
-    <%= form.text_area :description, class: "borderedInput body1" %>
+        <p class="subtitle"><%= t('views.show_item.description')%></p>
+        <%= form.text_area :description, class: "borderedInput body1" %>
 
-    <p class="subtitle"><%= t('views.show_item.owner')%></p>
-    <div class="notBorderedInput">
-      <%= form.collection_select(:owner, User.all, :id, :email, :include_blank => true)%>
+        <p class="subtitle"><%= t('views.show_item.owner')%></p>
+        <div class="notBorderedInput">
+          <%= form.collection_select(:owner, User.all, :id, :email, :include_blank => true)%>
+        </div>
+
+        <p class="subtitle"><%= t('views.show_item.holder')%></p>
+        <div class="notBorderedInput">
+          <%= form.collection_select(:holder, User.all, :id, :email, :include_blank => true)%>
+        </div>
+
+        <p class="subtitle"><%= t('views.edit_item.price_ct')%></p>
+        <%= form.number_field :price_ct, class: "borderedInput body1" %>
+
+        <p class="subtitle"><%= t('views.edit_item.rental_duration_sec')%></p>
+        <%= form.number_field :rental_duration_sec, class: "borderedInput body1" %>
+
+        <p class="subtitle"><%= t('views.edit_item.return_checklist')%></p>
+        <%= form.text_area :return_checklist, class: "borderedInput body1" %> 
+
+        <div class="" id="buttonDiv">
+          <%= form.submit t('defaults.submit'), class: "btn-primary"%>
+          <%= link_to @item_new do %>
+            <button class="btn-secondary"><%= t('defaults.delete')%></button>
+          <% end %>
+        </div>
+      </div>
     </div>
-
-    <p class="subtitle"><%= t('views.show_item.holder')%></p>
-    <div class="notBorderedInput">
-      <%= form.collection_select(:holder, User.all, :id, :email, :include_blank => true)%>
-    </div>
-
-    <p class="subtitle"><%= t('views.edit_item.price_ct')%></p>
-    <%= form.number_field :price_ct, class: "borderedInput body1" %>
-
-    <p class="subtitle"><%= t('views.edit_item.rental_duration_sec')%></p>
-    <%= form.number_field :rental_duration_sec, class: "borderedInput body1" %>
-
-    <p class="subtitle"><%= t('views.edit_item.return_checklist')%></p>
-    <%= form.text_area :return_checklist, class: "borderedInput body1" %> 
-
-    <div class="" id="buttonDiv">
-      <%= form.submit t('defaults.submit'), class: "btn-primary"%>
-      <%= link_to @item_new do %>
-        <button class="btn-secondary"><%= t('defaults.delete')%></button>
-      <% end %>
-    </div>
-  </div>
   </div>
 <% end %>
 </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -149,7 +149,7 @@
         </p>
         <%= render "adaptive_lend_button", current_user: current_user, item: @item %>
         <div class="text-center">
-          <% if !current_user.nil? && current_user.id == @item.owner %>
+          <% if !current_user.nil? && current_user == @item.owning_user %>
             <%= link_to t("views.show_item.qr_button"), { action: "generate_qrcode"}, class: "btn-primary" %>
           <% end %>
         </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -90,29 +90,6 @@
       'GRAD' 0,
       'opsz' 48
   }
-
-  @media screen and (min-width: 768px) {
-    .image{
-      position:relative;
-      overflow:hidden;
-      padding-bottom:20em;
-      width: 23em;
-      height: 23em !important;
-      padding-left: 0px;
-      padding-right: 0px;   
-    }
-    .image img{
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translateX(-50%) translateY(-50%);
-      border-radius: 5px;
-    }
-    .centeredContainer{
-      margin: 0 auto;
-      width: 25em;
-    }
-  }
   
 </style>
 <div>
@@ -126,49 +103,56 @@
     <% end %>
   <% end %>
   
-  <div class="row">
-    <div class="centeredContainer">
-      <div class="text-center">
+  <div class="container">
+    <div class="row row-cols-1 row-cols-md-2">
+      <div class="text-center col">
         <div class="image container-fluid rounded">
           <!--only show filled icon if icon is on wishlist-->
           <!--span class="material-symbols-outlined wishlistIcon" id="filledWishlistIcon">grade</span-->
           <span class="material-symbols-outlined wishlistIcon" id="notFilledWishlistIcon">grade</span>
           <%= image_tag @item.image, class: "img img-responsive img-fluid rounded mx-auto d-block" if @item.image.attached?%>
         </div>
-        <div>
-          <p class="title"><%=@item.name %></p>
-        </div>
-        <p class="body-1" id="location">
-          <span class="material-symbols-outlined" id="locationIcon">
-            location_on</span>
-          <%= @item.location %></p>
-        <br>
       </div>
-      <p class="subtitle"><%= t('views.show_item.category')%></p>
-      <p class="body-1"><%= @item.category %></p>
-      <p class="subtitle"><%= t('views.show_item.description')%></p>
-      <p class="body-1"><%= @item.description %></p>
-      <p class="subtitle"><%= t('views.show_item.owner')%></p>
-      <p class="body-1"><%= User.find(@item.owner).email %></p>
-      <p class="subtitle"><%= t('views.show_item.lend_until')%></p>
-      <p class="body-1"><%= ((@item.rental_start.nil? ? Time.now() : @item.rental_start) + (@item.rental_duration_sec.nil? ? 86400 : @item.rental_duration_sec)).strftime('%d.%m.%Y') %></p>
-      <p class="subtitle"><%= t('views.show_item.waitlist')%></p>
-      <p class="body-1">
-        <% if !current_user.nil? %>
-          <% if !@item.waitlist.users.exists?(current_user.id) %>
-            <%= t('views.show_item.users_waiting', amount: @item.waitlist.users.size) %>
-          <% else %>
-            <%= t('views.show_item.waitlist_position', position: @item.waitlist.users.find_index(current_user) + 1) %>
+        
+      <div class="col">
+          <div>
+            <div>
+              <p class="title"><%=@item.name %></p>
+            </div>
+            <p class="body-1" id="location">
+            <span class="material-symbols-outlined" id="locationIcon">
+              location_on</span>
+            <%= @item.location %></p>
+            <br>
+          </div> 
+    
+
+        <p class="subtitle"><%= t('views.show_item.category')%></p>
+        <p class="body-1"><%= @item.category %></p>
+        <p class="subtitle"><%= t('views.show_item.description')%></p>
+        <p class="body-1"><%= @item.description %></p>
+        <p class="subtitle"><%= t('views.show_item.owner')%></p>
+        <p class="body-1"><%= User.find(@item.owner).email %></p>
+        <p class="subtitle"><%= t('views.show_item.lend_until')%></p>
+        <p class="body-1"><%= ((@item.rental_start.nil? ? Time.now() : @item.rental_start) + (@item.rental_duration_sec.nil? ? 86400 : @item.rental_duration_sec)).strftime('%d.%m.%Y') %></p>
+        <p class="subtitle"><%= t('views.show_item.waitlist')%></p>
+        <p class="body-1">
+          <% if !current_user.nil? %>
+            <% if !@item.waitlist.users.exists?(current_user.id) %>
+              <%= t('views.show_item.users_waiting', amount: @item.waitlist.users.size) %>
+            <% else %>
+              <%= t('views.show_item.waitlist_position', position: @item.waitlist.users.find_index(current_user) + 1) %>
+            <% end %>
           <% end %>
-        <% end %>
-      </p>
-      <%= render "adaptive_lend_button", current_user: current_user, item: @item %>
-      <div class="text-center">
-        <% if !current_user.nil? && current_user.id == @item.owner %>
-          <%= link_to t("views.show_item.qr_button"), { action: "generate_qrcode"}, class: "btn-primary" %>
-        <% end %>
+        </p>
+        <%= render "adaptive_lend_button", current_user: current_user, item: @item %>
+        <div class="text-center">
+          <% if !current_user.nil? && current_user.id == @item.owner %>
+            <%= link_to t("views.show_item.qr_button"), { action: "generate_qrcode"}, class: "btn-primary" %>
+          <% end %>
+        </div>
+        </div>
+        <br><br><br>
       </div>
-      <br><br><br>
     </div>
   </div>
-</div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,8 +14,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_180533) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_180533) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end


### PR DESCRIPTION
Fixes #211

This increases the width of all items views. Example
![image](https://user-images.githubusercontent.com/66524915/211519058-5b3812bb-55fa-4b1a-a77a-b26aeb1cd664.png)
![image](https://user-images.githubusercontent.com/66524915/211519168-503051fc-30d6-4541-8801-d75a7f248dec.png)

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [ ] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
