### PR TITLE
Adapt the number of items in one line according to the screen size

### DIFF
--- a/app/assets/stylesheets/itemcard.scss
+++ b/app/assets/stylesheets/itemcard.scss
@@ -21,6 +21,5 @@
 
 .itemcard .card-body .card-title{
     white-space: nowrap;
-    overflow: hidden;
     padding: 0 var(--bs-card-spacer-x);
 }

--- a/app/views/dashboard/_lent_items.html.erb
+++ b/app/views/dashboard/_lent_items.html.erb
@@ -1,37 +1,38 @@
 <style>
 
-  #hourglass_empty{
-    text-align: center;
-  }
+    #hourglass_empty {
+        text-align: center;
+    }
 
-  #hourglass_emptyIcon{
-    font-size: 12px;
-    vertical-align: text-top;
-  }
+    #hourglass_emptyIcon {
+        font-size: 12px;
+        vertical-align: text-top;
+    }
 
 </style>
 
 <div>
   <% items = Item.where(holder: current_user) %>
-  <% items = items.sort_by{|item| item.rental_end} %>
+  <% items = items.sort_by { |item| item.rental_end } %>
   <% if items.empty? %>
-    <p class="body-1"><%=t 'views.dashboard.lent_items.no_lent_items' %></p>
+    <p class="body-1"><%= t 'views.dashboard.lent_items.no_lent_items' %></p>
   <% else %>
     <div class="container">
-      <div class="row row-cols-1 row-cols-md-4 g-4">
+      <div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-lg-5 row-cols-xl-6 g-4">
         <% items.each do |item| %>
           <div>
             <%= render :partial => "partials/itemcard", :locals => { :item => item } %>
-              <div class="progress mb-2">
-                <div class="progress-bar" role="progressbar" style="width:<%= item.progress_lent_time %>%" aria-valuenow="<%= item.progress_lent_time %>%" aria-valuemin="0" aria-valuemax="100"></div>
-              </div>
-              <p
-                <% if item.remaining_rental_duration < 172_800 %> class="caption-secondary text-center"
-                <% elsif item.remaining_rental_duration < 604_800 %> class="caption-primary text-center"
-                <% else %>  class="caption" <% end %> id="hourglass_empty">
-                <span class="material-symbols-outlined text-center" id="hourglass_emptyIcon"> hourglass_empty </span>
-                <%= item.print_remaining_rental_duration%>
-              </p>
+            <div class="progress mb-2">
+              <div class="progress-bar" role="progressbar" style="width:<%= item.progress_lent_time %>%" aria-valuenow="<%= item.progress_lent_time %>%" aria-valuemin="0" aria-valuemax="100"></div>
+            </div>
+            <p
+              <% if item.remaining_rental_duration < 172_800 %> class="caption-secondary text-center"
+              <% elsif item.remaining_rental_duration < 604_800 %> class="caption-primary text-center"
+              <% else %>  class="caption"
+              <% end %> id="hourglass_empty">
+              <span class="material-symbols-outlined text-center" id="hourglass_emptyIcon"> hourglass_empty </span>
+              <%= item.print_remaining_rental_duration %>
+            </p>
           </div>
         <% end %>
       </div>

--- a/app/views/dashboard/_offered_items.html.erb
+++ b/app/views/dashboard/_offered_items.html.erb
@@ -4,7 +4,7 @@
     <p class="body-1"><%= t 'views.dashboard.offered_items.nothing_offered' %></p>
   <% else %>
     <div class="container">
-      <div class="row row-cols-1 row-cols-md-4 g-4">
+      <div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-lg-5 row-cols-xl-6 g-4">
         <% items.each do |item| %>
           <div>
             <%= render :partial => "partials/itemcard", :locals => { :item => item } %>

--- a/app/views/dashboard/_offered_items.html.erb
+++ b/app/views/dashboard/_offered_items.html.erb
@@ -15,7 +15,7 @@
             <% else %>
               <p class="caption mb-1 text-center"><%= t 'views.dashboard.offered_items.lent' %></p>
               <% if item.remaining_rental_duration <= 0 %>
-                <div class="caption-secondary text-center"><%= t 'views.dashboard.offered_items.overdue' %></div>
+                <p class="caption-secondary text-center"><%= t 'views.dashboard.offered_items.overdue' %></p>
               <% end %>
             <% end %>
           </div>

--- a/app/views/dashboard/_wishlist.html.erb
+++ b/app/views/dashboard/_wishlist.html.erb
@@ -4,10 +4,10 @@
     <p class="body-1"><%= t 'views.dashboard.wishlist.missing_wishlist' %></p>
   <% else %>
     <div class="container">
-      <div class="row row-cols-1 row-cols-md-4 g-4">
+      <div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-lg-5 row-cols-xl-6 g-4">
         <% wishlist.each do |item| %>
           <div>
-            <%= render :partial => "partials/itemcard", :locals => { :item => item} %>
+            <%= render :partial => "partials/itemcard", :locals => { :item => item } %>
             <% if item.holder.nil? %>
               <p class="caption-primary text-center"><%= t 'views.dashboard.wishlist.available' %></p>
             <% elsif item.holder == current_user.id %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -3,215 +3,230 @@
 
 
 <style>
-:root{
-  --grey04: #394044;
-  --grey09: #AAB0B3;
-  --grey11: #DDDFE0;
-  --secondary08: #55A6BE;
-  }
-  .caption{
-    text-align: center;
-  }
-  .subtitle{
-     margin-bottom: 0px;
-  }
-  .title{
-    font-family: Roboto;
-    font-style: normal;
-    font-weight: 700;
-    font-size: 20px;
-    line-height: 23px;
-    text-align: center;
-    text-transform: capitalize;
-    color: var(--grey04);
-    margin: 1em 0px 0px 0px;
-  }
-  #location{
-      text-align: center;
-  }
-  .centeredContainer{
-      margin: 0 auto;
-      width: 65%;
-  }
-  .image{
-    position:relative;
-    overflow:hidden;
-    padding-bottom:100%;
-    max-width: 25em;
-    max-height: 25em !important; 
-    padding-left: 0px;
-    padding-right: 0px;  
-  }
-  .image img{
-    position:absolute;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    max-height: 25em !important;
-  }
+    :root {
+        --grey04: #394044;
+        --grey09: #AAB0B3;
+        --grey11: #DDDFE0;
+        --secondary08: #55A6BE;
+    }
 
-  #locationIcon{
-    font-size: 20px;
-    vertical-align: text-top;
-  }
+    .caption {
+        text-align: center;
+    }
 
-  .material-symbols-outlined{
-    color: var(--grey04);
-  }
+    .subtitle {
+        margin-bottom: 0px;
+    }
 
-  #imagePlaceholder {
-    background-color: var(--grey11);
-    position:absolute;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    max-height: 25em !important;
-  }
+    .title {
+        font-family: Roboto;
+        font-style: normal;
+        font-weight: 700;
+        font-size: 20px;
+        line-height: 23px;
+        text-align: center;
+        text-transform: capitalize;
+        color: var(--grey04);
+        margin: 1em 0px 0px 0px;
+    }
 
-  #imageIcon {
-     font-size: 10em;
-     color: var(--grey09);
-  }
+    #location {
+        text-align: center;
+    }
 
-  .notBorderedInput {
-    width: 100%;
-    margin-bottom: 8px
-  }
-  .borderedInput {
-    border: 1px solid #AAB0B3;
-    border-radius: 5px; 
-    padding-left: 5px;
-    width: 100%;
-    margin-bottom: 8px
-  }
-  .locationInput {
-    width: 90%;
-  }
-  .btn-primary {
-    margin-bottom: 8px;
-    width: 48%;
-    display: inline-block;
-  }
-  .btn-secondary {
-    width: 48%;
-    display: inline-block;
-  }
-  #buttonDiv {
-    width: 100%;
-    text-align: center;
-  }
-  .caption{
-    text-align: left;
-  }
-  select {
-    width: 100%;
-  }
+    .centeredContainer {
+        margin: 0 auto;
+        width: 65%;
+    }
+
+    .image {
+        position: relative;
+        overflow: hidden;
+        padding-bottom: 100%;
+        max-width: 25em;
+        max-height: 25em !important;
+        padding-left: 0px;
+        padding-right: 0px;
+    }
+
+    .image img {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        max-height: 25em !important;
+    }
+
+    #locationIcon {
+        font-size: 20px;
+        vertical-align: text-top;
+    }
+
+    .material-symbols-outlined {
+        color: var(--grey04);
+    }
+
+    #imagePlaceholder {
+        background-color: var(--grey11);
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        max-height: 25em !important;
+    }
+
+    #imageIcon {
+        font-size: 10em;
+        color: var(--grey09);
+    }
+
+    .notBorderedInput {
+        width: 100%;
+        margin-bottom: 8px
+    }
+
+    .borderedInput {
+        border: 1px solid #AAB0B3;
+        border-radius: 5px;
+        padding-left: 5px;
+        width: 100%;
+        margin-bottom: 8px
+    }
+
+    .locationInput {
+        width: 90%;
+    }
+
+    .btn-primary {
+        margin-bottom: 8px;
+        width: 48%;
+        display: inline-block;
+    }
+
+    .btn-secondary {
+        width: 48%;
+        display: inline-block;
+    }
+
+    #buttonDiv {
+        width: 100%;
+        text-align: center;
+    }
+
+    .caption {
+        text-align: left;
+    }
+
+    select {
+        width: 100%;
+    }
 </style>
 <script>
-(function() {
-  // Load the script
-  const script = document.createElement("script");
-  script.src = 'https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js';
-  script.type = 'text/javascript';
-  document.head.appendChild(script);
-})();
+    (function () {
+        // Load the script
+        const script = document.createElement("script");
+        script.src = 'https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js';
+        script.type = 'text/javascript';
+        document.head.appendChild(script);
+    })();
 
-function readURL(input) {
-    if (input.files && input.files[0]) {
-      let reader = new FileReader();
+    function readURL(input) {
+        if (input.files && input.files[0]) {
+            let reader = new FileReader();
 
-      reader.addEventListener("load", (e) => {
-        $('#img_prev').attr('src', e.target.result);
-        // remove the background color since hide() doesnt work
-        $('#imagePlaceholder').css("background-color", "transparent");
-        $('#imageIcon').hide();
-        });
-      reader.readAsDataURL(input.files[0]);
+            reader.addEventListener("load", (e) => {
+                $('#img_prev').attr('src', e.target.result);
+                // remove the background color since hide() doesnt work
+                $('#imagePlaceholder').css("background-color", "transparent");
+                $('#imageIcon').hide();
+            });
+            reader.readAsDataURL(input.files[0]);
+        }
     }
-  }
 </script>
 <div>
-<%= form_with(model: @item, :html => {:multipart => true}) do |form| %>
+  <%= form_with(model: @item, :html => { :multipart => true }) do |form| %>
 
-  <% if @item.errors.any? %>
-    <div style="color: red">
-      <h2><%= pluralize(@item.errors.count, "error") %> prohibited this item from being saved:</h2>
+    <% if @item.errors.any? %>
+      <div style="color: red">
+        <h2><%= pluralize(@item.errors.count, "error") %> prohibited this item from being saved:</h2>
 
-      <ul>
-        <% @item.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+        <ul>
+          <% @item.errors.each do |error| %>
+            <li><%= error.full_message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
 
-  <div class="container">
-    <div class="row row-cols-1 row-cols-md-2">
-      <div class="text-center col">
+    <div class="container">
+      <div class="row row-cols-1 row-cols-md-2">
+        <div class="text-center col">
 
-        <div class="image container-fluid rounded">
-          <img id="img_prev" class="img img-responsive img-fluid rounded mx-auto d-flex align-items-center justify-content-center" src="#" alt=""/>
-          <div class="img img-responsive img-fluid rounded mx-auto d-flex align-items-center justify-content-center" id=imagePlaceholder>
-            <span class="material-symbols-outlined" id="imageIcon">image</span>
-          </div> 
+          <div class="image container-fluid rounded">
+            <img id="img_prev" class="img img-responsive img-fluid rounded mx-auto d-flex align-items-center justify-content-center" src="#" alt=""/>
+            <div class="img img-responsive img-fluid rounded mx-auto d-flex align-items-center justify-content-center" id=imagePlaceholder>
+              <span class="material-symbols-outlined" id="imageIcon">image</span>
+            </div>
+          </div>
+
+          <%= form.file_field :image, multiple: false, direct_upload: true, :onchange => "readURL(this)" %>
+
         </div>
 
-        <%= form.file_field :image, multiple: false, direct_upload: true, :onchange => "readURL(this)"%>
 
-      </div>  
-
-
-      <div class="col">
-        <div>
-          <p class="title">
-            <%= form.text_field :name, class: "borderedInput", placeholder: t('views.new_item.item_name')+"*" %>
-          </p>
-          <div class="row">
-            <p class="body1" id="location">
-              <span class="material-symbols-outlined" id="locationIcon">location_on</span>
-              <%= form.text_field :location, class: "locationInput borderedInput", placeholder: t('views.new_item.location')+"*" %>
+        <div class="col">
+          <div>
+            <p class="title">
+              <%= form.text_field :name, class: "borderedInput", placeholder: t('views.new_item.item_name') + "*" %>
             </p>
-        </div>
-      
-        <p class="subtitle"><%= t('views.show_item.category')%>*</p>
-        <%= form.text_field :category, class: "borderedInput body1" %>
+            <div class="row">
+              <p class="body1" id="location">
+                <span class="material-symbols-outlined" id="locationIcon">location_on</span>
+                <%= form.text_field :location, class: "locationInput borderedInput", placeholder: t('views.new_item.location') + "*" %>
+              </p>
+            </div>
 
-        <p class="subtitle"><%= t('views.show_item.description')%></p>
-        <%= form.text_area :description, class: "borderedInput body1" %>
+            <p class="subtitle"><%= t('views.show_item.category') %>*</p>
+            <%= form.text_field :category, class: "borderedInput body1" %>
 
-        <p class="subtitle"><%= t('views.show_item.owner')%>*</p>
-        <div class="notBorderedInput">
-          <% if current_user.nil? %>
-            <%= form.collection_select(:owner_id, [], :id, :email, :include_blank => true) %>
-          <% else %>
-            <%= form.collection_select(:owner_id, [current_user], :id, :email, :selected => current_user.id) %>
-          <% end %>
-        </div>
+            <p class="subtitle"><%= t('views.show_item.description') %></p>
+            <%= form.text_area :description, class: "borderedInput body1" %>
 
-        <p class="subtitle"><%= t('views.show_item.holder')%></p>
-        <div class="notBorderedInput">
-          <%= form.collection_select(:holder, User.all, :id, :email, :include_blank => true)%>
-        </div>
+            <p class="subtitle"><%= t('views.show_item.owner') %>*</p>
+            <div class="notBorderedInput">
+              <% if current_user.nil? %>
+                <%= form.collection_select(:owner_id, [], :id, :email, :include_blank => true) %>
+              <% else %>
+                <%= form.collection_select(:owner_id, [current_user], :id, :email, :selected => current_user.id) %>
+              <% end %>
+            </div>
 
-        <p class="subtitle"><%= t('views.edit_item.price_ct')%></p>
-        <%= form.number_field :price_ct, class: "borderedInput body1" %>
+            <p class="subtitle"><%= t('views.show_item.holder') %></p>
+            <div class="notBorderedInput">
+              <%= form.collection_select(:holder, User.all, :id, :email, :include_blank => true) %>
+            </div>
 
-        <p class="subtitle"><%= t('views.edit_item.rental_duration_sec')%>*</p>
-        <%= form.number_field :rental_duration_sec, class: "borderedInput body1" %>
+            <p class="subtitle"><%= t('views.edit_item.price_ct') %></p>
+            <%= form.number_field :price_ct, class: "borderedInput body1" %>
 
-        <p class="subtitle"><%= t('views.edit_item.return_checklist')%></p>
-        <%= form.text_area :return_checklist, class: "borderedInput body1" %> 
+            <p class="subtitle"><%= t('views.edit_item.rental_duration_sec') %>*</p>
+            <%= form.number_field :rental_duration_sec, class: "borderedInput body1" %>
 
-        <p class="caption">* <%= t('views.new_item.required_fields')%></p>
+            <p class="subtitle"><%= t('views.edit_item.return_checklist') %></p>
+            <%= form.text_area :return_checklist, class: "borderedInput body1" %>
 
-        <div class="" id="buttonDiv">
-          <%= form.submit t('defaults.submit'), class: "btn-primary"%>
-          <%= link_to @item_new do %>
-            <button class="btn-secondary"><%= t('defaults.delete')%></button>
-          <% end %>
+            <p class="caption">* <%= t('views.new_item.required_fields') %></p>
+
+            <div class="" id="buttonDiv">
+              <%= form.submit t('defaults.submit'), class: "btn-primary" %>
+              <%= link_to @item_new do %>
+                <button class="btn-secondary"><%= t('defaults.delete') %></button>
+              <% end %>
+            </div>
+          </div>
         </div>
       </div>
-    </div>
+  <% end %>
   </div>
-<% end %>
 </div>

--- a/app/views/partials/_itemcard.html.erb
+++ b/app/views/partials/_itemcard.html.erb
@@ -8,7 +8,7 @@
                 <%= image_tag("image_default.svg", class: "card-img-top filter-gray") %>
               <% end %>
             </div>
-            <h5 class="card-title mt-1"><%= item.name %></h5>
+            <div class="body-2 card-title mt-2 text-truncate"><%= item.name %></div>
             <a href="<%= item_path(item) %>" class="stretched-link"></a>
         </div>
     </div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,29 +1,29 @@
 <div data-controller="qrscanner">
-    <%= render "qr-scanner" %>
+  <%= render "qr-scanner" %>
 
-    <%= form_tag(search_path, method: :get) do %>
-        <div class="input-group mb-3">
-            <%= text_field_tag :search, params[:search], class: "form-control outline-missing-right", placeholder: t('views.search.title') %>
-            <button type="submit" id="submit" class="btn btn-outline-secondary outline-missing-left outline-missing-right">
-                <i class="bi bi-search"></i>
-            </button>
-            <button type="button" class="btn btn-outline-secondary outline-missing-left" data-bs-toggle="modal" data-bs-target="#qrscanner" data-action="click->qrscanner#open">
-                <i class="bi bi-qr-code-scan"></i>
-            </button>
-        </div>
-        <button class="btn btn-secondary secondaryButton" type="button" data-bs-toggle="modal" data-bs-target="#filter-modal" aria-expanded="false">
-            <%= t 'views.search.filter_button' %> <i class="bi bi-sliders2-vertical"></i>
-        </button>
-        <%= render "filter-modal" %>
+  <%= form_tag(search_path, method: :get) do %>
+    <div class="input-group mb-3">
+      <%= text_field_tag :search, params[:search], class: "form-control outline-missing-right", placeholder: t('views.search.title') %>
+      <button type="submit" id="submit" class="btn btn-outline-secondary outline-missing-left outline-missing-right">
+        <i class="bi bi-search"></i>
+      </button>
+      <button type="button" class="btn btn-outline-secondary outline-missing-left" data-bs-toggle="modal" data-bs-target="#qrscanner" data-action="click->qrscanner#open">
+        <i class="bi bi-qr-code-scan"></i>
+      </button>
+    </div>
+    <button class="btn btn-secondary secondaryButton" type="button" data-bs-toggle="modal" data-bs-target="#filter-modal" aria-expanded="false">
+      <%= t 'views.search.filter_button' %> <i class="bi bi-sliders2-vertical"></i>
+    </button>
+    <%= render "filter-modal" %>
 
-        <%= text_field_tag :lastsearch, params[:lastsearch], class: "form-control invisible", value: @lastsearch %>
-    <% end %>
+    <%= text_field_tag :lastsearch, params[:lastsearch], class: "form-control invisible", value: @lastsearch %>
+  <% end %>
 </div>
 
 <% if @results %>
-    <div class="row row-cols-1 row-cols-md-4 g-3">
-        <% @results.each do |result| %>
-            <%= render :partial => "partials/itemcard", :locals => { :item => result } %>
-        <% end %>
-    </div>
+  <div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-lg-5 row-cols-xl-6 g-3">
+    <% @results.each do |result| %>
+      <%= render :partial => "partials/itemcard", :locals => { :item => result } %>
+    <% end %>
+  </div>
 <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,8 +14,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_10_161824) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_10_161824) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
+    t.integer "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end


### PR DESCRIPTION
Fixes #252 

Description: Scales the number of items from 2 to 6 depending on screensize on the dashboard and the search page

<img width="377" alt="Screenshot_20230116_120124" src="https://user-images.githubusercontent.com/82881590/212663178-4e1349de-94b0-47ee-b9fa-968ddd60a7aa.png">
<img width="566" alt="Screenshot_20230116_120056" src="https://user-images.githubusercontent.com/82881590/212663182-6b32f463-db2c-48ab-a7ae-0add946b753f.png">
<img width="714" alt="Screenshot_20230116_120002" src="https://user-images.githubusercontent.com/82881590/212663184-2ed59cce-0000-42b9-adde-7b2e902a0145.png">
<img width="854" alt="Screenshot_20230116_115940" src="https://user-images.githubusercontent.com/82881590/212663186-ed90264b-7347-4f16-8bdd-479ea0e2ea0f.png">
<img width="960" alt="Screenshot_20230116_115858" src="https://user-images.githubusercontent.com/82881590/212663187-cf995fa0-85e3-4943-b560-5eaee64adcd2.png">

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
