### PR TITLE
Feature/hghk 285 add members to group

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,6 +1,7 @@
 class GroupsController < ApplicationController
+  before_action :set_item, only: %i[ show create promote demote add_user ]
+
   def show
-    @group = Group.find(params[:id])
   end
 
   def new
@@ -8,7 +9,6 @@ class GroupsController < ApplicationController
   end
 
   def create
-    @group = Group.new(group_params)
     @group.owners.append(current_user)
     if @group.save
       redirect_to @group
@@ -18,8 +18,6 @@ class GroupsController < ApplicationController
   end
 
   def promote
-    @group = Group.find(params[:id])
-
     if @group.owners.include?(current_user)
       @user = User.find(params[:user_id])
       @user.to_owner_of! @group
@@ -29,8 +27,6 @@ class GroupsController < ApplicationController
   end
 
   def demote
-    @group = Group.find(params[:id])
-
     if @group.owners.include?(current_user)
       @user = User.find(params[:user_id])
       @user.to_member_of! @group
@@ -39,7 +35,21 @@ class GroupsController < ApplicationController
     redirect_to @group
   end
 
+  def add_user
+    user = User.find(params[:user_id])
+    if user.nil?
+      format.html { render :show, status: :unprocessable_entity }
+    else
+      user.to_member_of!(@group)
+      format.html { redirect_to @group, notice: t("views.groups.user_addded", user: user.name) }
+    end
+  end
+
   def group_params
     params.require(:group).permit(:name)
+  end
+
+  def set_group
+    @group = Group.find(params[:id])
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,5 @@
 class GroupsController < ApplicationController
-  before_action :set_item, only: %i[ show create promote demote add_user ]
+  before_action :set_group, only: %i[ show create promote demote add_user ]
 
   def show
   end

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,4 +1,26 @@
-<h1><%= @group.name %></h1>
+<h1>
+    <%= @group.name %>
+
+    <% if @group.owners.include?(current_user) %>
+        <div class="dropdown" style="float: right;">
+            <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                <i class="bi bi-plus"></i>
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="dropdownMenuButton1">
+                <% @addable_users.each do |user| %>
+                    <li>
+                        <%= link_to user.name, group_add_user_path(@group, user), class: "dropdown-item", data: {turbo_method: :post} %>
+                    </li>
+                <% end %>
+                <% if @addable_users.empty? %>
+                    <li>
+                        <i><%= t 'views.groups.no_addable_users' %></i>
+                    </li>
+                <% end %>
+            </ul>
+        </div>
+    <% end %>
+</h1>
 
 <h2><%= t 'views.groups.owners' %></h2>
 <ul id="group-owners">

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -132,6 +132,7 @@ de:
       promote: "Zu Admin machen"
       demote: "Admin entfernen"
       user_added: "Mitglied %{user} wurde hinzugefügt"
+      no_addable_users: "Keine Nutzer zum Hinzufügen gefunden"
   models:
     item:
       item: "Gegenstand"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -131,6 +131,7 @@ de:
       members: "Mitglieder"
       promote: "Zu Admin machen"
       demote: "Admin entfernen"
+      user_added: "Mitglied %{user} wurde hinzugefügt"
   models:
     item:
       item: "Gegenstand"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,6 +161,7 @@ en:
       promote: "Make owner"
       demote: "Remove owner"
       user_added: "Member %{user} added successfully"
+      no_addable_users: "No addable users found"
   models:
     item:
       item: "Item"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,6 +160,7 @@ en:
       members: "Members"
       promote: "Make owner"
       demote: "Remove owner"
+      user_added: "Member %{user} added successfully"
   models:
     item:
       item: "Item"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
   resources :groups
   post 'groups/:id/promote/:user_id', to: 'groups#promote', as: 'group_promote'
   post 'groups/:id/demote/:user_id', to: 'groups#demote', as: 'group_demote'
+  post 'groups/:id/add_user/:user_id', to: 'groups#add_user', as: 'group_add_user'
   # Defines the root path route ("/")
   root "landing_page#index"
 end


### PR DESCRIPTION
Fixes #285

This MR adds a button to the group view for owners to add new users as members. 

## PR checklist

- [ ] dev-branch has been merged into local branch to resolve conflicts
- [ ] tests and linter have passed AFTER local merge
- [ ] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [ ] another dev reviewed and approved
- [ ] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
