### PR TITLE
Feature: Show all items on empty search string

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,6 +1,6 @@
 class SearchController < ApplicationController
   def index
-    search_term = params[:search]  
+    search_term = params[:search]
     @results = helpers.search_for_items(search_term)
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,12 +1,6 @@
 class SearchController < ApplicationController
   def index
-    search_term = params[:search]
-    if search_term.blank?
-      @lastsearch = params[:lastsearch]
-      search_term = @lastsearch
-    else
-      @lastsearch = search_term
-    end
+    search_term = params[:search]  
     @results = helpers.search_for_items(search_term)
   end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -9,7 +9,7 @@ module SearchHelper
   # filter_numerical: filter search by numerial range in the form:
   # {"search_name" => {"lower_bound" => 8, "upper_bound" => 10}, ...}
   def search_for_items(search_term, filter_category = {}, filter_numerical = {})
-    return [] if search_term.blank?
+    return Item.all if search_term.blank?
 
     partial_matching_clause = create_partial_matching_clause(search_term)
     categorial_attribute_clause = create_mutiple_attribute_clause(filter_category, relevant_categorial_attribute,

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -30,8 +30,6 @@
             <%= t 'views.search.filter_button' %> <i class="bi bi-sliders2-vertical"></i>
         </button>
         <%= render "filter-modal" %>
-
-        <%= text_field_tag :lastsearch, params[:lastsearch], class: "form-control invisible", value: @lastsearch %>
     <% end %>
 </div>
 

--- a/spec/features/search/search_spec.rb
+++ b/spec/features/search/search_spec.rb
@@ -45,7 +45,7 @@ describe "Search page", type: :feature do
     expect(page).to have_text(@item_whiteboard.name)
   end
 
-  it "shows no item at first if you visit the page" do
+  it "shows all items at first if you visit the page" do
     expect(page).to have_text(@item_book.name)
     expect(page).to have_text(@item_beamer.name)
     expect(page).to have_text(@item_whiteboard.name)

--- a/spec/features/search/search_spec.rb
+++ b/spec/features/search/search_spec.rb
@@ -40,25 +40,25 @@ describe "Search page", type: :feature do
   it "partial matching works for empty string" do
     page.fill_in "search", with: ""
     click_button("submit")
-    expect(page).not_to have_text(@item_book.name)
-    expect(page).not_to have_text(@item_beamer.name)
-    expect(page).not_to have_text(@item_whiteboard.name)
+    expect(page).to have_text(@item_book.name)
+    expect(page).to have_text(@item_beamer.name)
+    expect(page).to have_text(@item_whiteboard.name)
   end
 
   it "shows no item at first if you visit the page" do
-    expect(page).not_to have_text(@item_book.name)
-    expect(page).not_to have_text(@item_beamer.name)
-    expect(page).not_to have_text(@item_whiteboard.name)
+    expect(page).to have_text(@item_book.name)
+    expect(page).to have_text(@item_beamer.name)
+    expect(page).to have_text(@item_whiteboard.name)
   end
 
-  it "shows last search result when searching for nothing after searching for something" do
+  it "shows all items when searching for nothing after searching for something" do
     page.fill_in "search", with: "book"
     click_button("submit")
     page.fill_in "search", with: ""
     click_button("submit")
     expect(page).to have_text(@item_book.name)
-    expect(page).not_to have_text(@item_beamer.name)
-    expect(page).not_to have_text(@item_whiteboard.name)
+    expect(page).to have_text(@item_beamer.name)
+    expect(page).to have_text(@item_whiteboard.name)
   end
 
 end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -29,12 +29,12 @@ RSpec.describe "Search", type: :helper do
 
   it "Searches correctly for empty string" do
     results = search_for_items("")
-    expect(results.length).to be(0)
+    expect(results.length).to be(3)
   end
 
   it "Searches correctly for string only with whitespaces" do
     results = search_for_items("   ")
-    expect(results.length).to be(0)
+    expect(results.length).to be(3)
   end
 
   it "Searches correctly for both items with 'to'" do


### PR DESCRIPTION
Fixes #291

If you enter an empty search string, the search page shows every item now (instead of the last search or nothing)

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
