### PR TITLE
Feature/br 220 rental duration sec to days

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -213,7 +213,7 @@ class ItemsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def item_params
-    params.require(:item).permit(:name, :category, :location, :description, :image, :price_ct, :rental_duration_sec,
+    params.require(:item).permit(:name, :category, :location, :description, :image, :price_ct, :rental_duration_days,
                                  :rental_start, :return_checklist, :holder, :waitlist_id, :lend_status)
           .merge!(owner_hash)
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -39,6 +39,7 @@ class Item < ApplicationRecord
   validates :lend_status, presence: true, inclusion: { in: lend_statuses.keys }
 
   before_save do
+    #convert rental duration to seconds
     self.rental_duration_sec = self.rental_duration_sec * 86400
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -33,7 +33,7 @@ class Item < ApplicationRecord
   validates :location, presence: true
   validates :ownership_permission, presence: true
   validates :price_ct, numericality: { allow_nil: true, greater_than_or_equal_to: 0 }
-  validates :rental_duration_sec, numericality: { allow_nil: true, greater_than_or_equal_to: 0 }
+  validates :rental_duration_days, numericality: { allow_nil: true, greater_than_or_equal_to: 0 }
   enum :lend_status,
        { available: 0, lent: 1, pending_return: 2, pending_lend_request: 3, pending_pickup: 4, unavailable: 5 }
   validates :lend_status, presence: true, inclusion: { in: lend_statuses.keys }
@@ -128,17 +128,17 @@ class Item < ApplicationRecord
   end
 
   def rental_end
-    return Time.now.utc if rental_start.nil? || rental_duration_sec.nil?
+    return Time.now.utc if rental_start.nil? || rental_duration_days.nil?
 
-    rental_start + rental_duration_sec * 86400
+    rental_start + rental_duration_days * 86400
   end
 
-  def remaining_rental_duration_sec
+  def remaining_rental_duration_days
     rental_end - Time.now.utc
   end
 
-  def print_remaining_rental_duration_sec
-    print_time_from_seconds(remaining_rental_duration_sec)
+  def print_remaining_rental_duration_days
+    print_time_from_seconds(remaining_rental_duration_days)
   end
 
   def print_time_from_seconds(seconds)
@@ -154,9 +154,9 @@ class Item < ApplicationRecord
   end
 
   def progress_lent_time
-    return 100 if rental_start.nil? || rental_duration_sec.nil? || rental_duration_sec.zero?
+    return 100 if rental_start.nil? || rental_duration_days.nil? || rental_duration_days.zero?
 
-    lent_time_progress = (((rental_duration_sec * 86400 - remaining_rental_duration_sec) * 100) / rental_duration_sec).to_i
+    lent_time_progress = (((rental_duration_days * 86400 - remaining_rental_duration_days) * 100) / rental_duration_days).to_i
     if lent_time_progress.negative?
       0
     elsif lent_time_progress > 100

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -38,6 +38,10 @@ class Item < ApplicationRecord
        { available: 0, lent: 1, pending_return: 2, pending_lend_request: 3, pending_pickup: 4, unavailable: 5 }
   validates :lend_status, presence: true, inclusion: { in: lend_statuses.keys }
 
+  before_save do
+    self.rental_duration_sec = self.rental_duration_sec * 86400
+  end
+
   def price_in_euro
     unless price_ct.nil?
       ct = price_ct % 100

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -157,7 +157,7 @@ class Item < ApplicationRecord
     return 100 if rental_start.nil? || rental_duration_days.nil? || rental_duration_days.zero?
 
     rental_duration_sec = rental_duration_days * 86_400
-    lent_time_progress = (((rental_duration_sec - remaining_rental_duration_sec) * 100) / rental_duration_days).to_i
+    lent_time_progress = (((rental_duration_sec - remaining_rental_duration_sec) * 100) / rental_duration_sec).to_i
     if lent_time_progress.negative?
       0
     elsif lent_time_progress > 100

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -130,15 +130,15 @@ class Item < ApplicationRecord
   def rental_end
     return Time.now.utc if rental_start.nil? || rental_duration_days.nil?
 
-    rental_start + rental_duration_days * 86400
+    rental_start + (rental_duration_days * 86_400)
   end
 
-  def remaining_rental_duration_days
+  def remaining_rental_duration_sec
     rental_end - Time.now.utc
   end
 
-  def print_remaining_rental_duration_days
-    print_time_from_seconds(remaining_rental_duration_days)
+  def print_remaining_rental_duration_sec
+    print_time_from_seconds(remaining_rental_duration_sec)
   end
 
   def print_time_from_seconds(seconds)
@@ -156,7 +156,8 @@ class Item < ApplicationRecord
   def progress_lent_time
     return 100 if rental_start.nil? || rental_duration_days.nil? || rental_duration_days.zero?
 
-    lent_time_progress = (((rental_duration_days * 86400 - remaining_rental_duration_days) * 100) / rental_duration_days).to_i
+    rental_duration_sec = rental_duration_days * 86_400
+    lent_time_progress = (((rental_duration_sec - remaining_rental_duration_sec) * 100) / rental_duration_days).to_i
     if lent_time_progress.negative?
       0
     elsif lent_time_progress > 100

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -38,11 +38,6 @@ class Item < ApplicationRecord
        { available: 0, lent: 1, pending_return: 2, pending_lend_request: 3, pending_pickup: 4, unavailable: 5 }
   validates :lend_status, presence: true, inclusion: { in: lend_statuses.keys }
 
-  before_save do
-    #convert rental duration to seconds
-    self.rental_duration_sec = self.rental_duration_sec * 86400
-  end
-
   def price_in_euro
     unless price_ct.nil?
       ct = price_ct % 100
@@ -135,15 +130,15 @@ class Item < ApplicationRecord
   def rental_end
     return Time.now.utc if rental_start.nil? || rental_duration_sec.nil?
 
-    rental_start + rental_duration_sec
+    rental_start + rental_duration_sec * 86400
   end
 
-  def remaining_rental_duration
+  def remaining_rental_duration_sec
     rental_end - Time.now.utc
   end
 
-  def print_remaining_rental_duration
-    print_time_from_seconds(remaining_rental_duration)
+  def print_remaining_rental_duration_sec
+    print_time_from_seconds(remaining_rental_duration_sec)
   end
 
   def print_time_from_seconds(seconds)
@@ -161,7 +156,7 @@ class Item < ApplicationRecord
   def progress_lent_time
     return 100 if rental_start.nil? || rental_duration_sec.nil? || rental_duration_sec.zero?
 
-    lent_time_progress = (((rental_duration_sec - remaining_rental_duration) * 100) / rental_duration_sec).to_i
+    lent_time_progress = (((rental_duration_sec * 86400 - remaining_rental_duration_sec) * 100) / rental_duration_sec).to_i
     if lent_time_progress.negative?
       0
     elsif lent_time_progress > 100

--- a/app/views/dashboard/_lent_items.html.erb
+++ b/app/views/dashboard/_lent_items.html.erb
@@ -26,11 +26,11 @@
                 <div class="progress-bar" role="progressbar" style="width:<%= item.progress_lent_time %>%"></div>
               </div>
               <p
-                <% if item.remaining_rental_duration_sec < 172_800 %> class="caption-secondary text-center"
-                <% elsif item.remaining_rental_duration_sec < 604_800 %> class="caption-primary text-center"
+                <% if item.remaining_rental_duration_days < 172_800 %> class="caption-secondary text-center"
+                <% elsif item.remaining_rental_duration_days < 604_800 %> class="caption-primary text-center"
                 <% else %>  class="caption" <% end %> id="hourglass_empty">
                 <span class="material-symbols-outlined text-center" id="hourglass_emptyIcon"> hourglass_empty </span>
-                <%= item.print_remaining_rental_duration_sec%>
+                <%= item.print_remaining_rental_duration_days%>
               </p>
           </div>
         <% end %>

--- a/app/views/dashboard/_lent_items.html.erb
+++ b/app/views/dashboard/_lent_items.html.erb
@@ -26,11 +26,11 @@
                 <div class="progress-bar" role="progressbar" style="width:<%= item.progress_lent_time %>%"></div>
               </div>
               <p
-                <% if item.remaining_rental_duration < 172_800 %> class="caption-secondary text-center"
-                <% elsif item.remaining_rental_duration < 604_800 %> class="caption-primary text-center"
+                <% if item.remaining_rental_duration_sec < 172_800 %> class="caption-secondary text-center"
+                <% elsif item.remaining_rental_duration_sec < 604_800 %> class="caption-primary text-center"
                 <% else %>  class="caption" <% end %> id="hourglass_empty">
                 <span class="material-symbols-outlined text-center" id="hourglass_emptyIcon"> hourglass_empty </span>
-                <%= item.print_remaining_rental_duration%>
+                <%= item.print_remaining_rental_duration_sec%>
               </p>
           </div>
         <% end %>

--- a/app/views/dashboard/_lent_items.html.erb
+++ b/app/views/dashboard/_lent_items.html.erb
@@ -26,11 +26,11 @@
                 <div class="progress-bar" role="progressbar" style="width:<%= item.progress_lent_time %>%"></div>
               </div>
               <p
-                <% if item.remaining_rental_duration_days < 172_800 %> class="caption-secondary text-center"
-                <% elsif item.remaining_rental_duration_days < 604_800 %> class="caption-primary text-center"
+                <% if item.remaining_rental_duration_sec < 172_800 %> class="caption-secondary text-center"
+                <% elsif item.remaining_rental_duration_sec < 604_800 %> class="caption-primary text-center"
                 <% else %>  class="caption" <% end %> id="hourglass_empty">
                 <span class="material-symbols-outlined text-center" id="hourglass_emptyIcon"> hourglass_empty </span>
-                <%= item.print_remaining_rental_duration_days%>
+                <%= item.print_remaining_rental_duration_sec%>
               </p>
           </div>
         <% end %>

--- a/app/views/dashboard/_offered_items.html.erb
+++ b/app/views/dashboard/_offered_items.html.erb
@@ -14,7 +14,7 @@
               <p class="caption text-center"><%= t 'views.dashboard.offered_items.lent_by_you' %></p>
             <% else %>
               <p class="caption mb-1 text-center"><%= t 'views.dashboard.offered_items.lent' %></p>
-              <% if item.remaining_rental_duration <= 0 %>
+              <% if item.remaining_rental_duration_sec <= 0 %>
                 <div class="caption-secondary text-center"><%= t 'views.dashboard.offered_items.overdue' %></div>
               <% end %>
             <% end %>

--- a/app/views/dashboard/_offered_items.html.erb
+++ b/app/views/dashboard/_offered_items.html.erb
@@ -14,7 +14,7 @@
               <p class="caption text-center"><%= t 'views.dashboard.offered_items.lent_by_you' %></p>
             <% else %>
               <p class="caption mb-1 text-center"><%= t 'views.dashboard.offered_items.lent' %></p>
-              <% if item.remaining_rental_duration_sec <= 0 %>
+              <% if item.remaining_rental_duration_days <= 0 %>
                 <div class="caption-secondary text-center"><%= t 'views.dashboard.offered_items.overdue' %></div>
               <% end %>
             <% end %>

--- a/app/views/dashboard/_offered_items.html.erb
+++ b/app/views/dashboard/_offered_items.html.erb
@@ -14,7 +14,7 @@
               <p class="caption text-center"><%= t 'views.dashboard.offered_items.lent_by_you' %></p>
             <% else %>
               <p class="caption mb-1 text-center"><%= t 'views.dashboard.offered_items.lent' %></p>
-              <% if item.remaining_rental_duration_days <= 0 %>
+              <% if item.remaining_rental_duration_sec <= 0 %>
                 <div class="caption-secondary text-center"><%= t 'views.dashboard.offered_items.overdue' %></div>
               <% end %>
             <% end %>

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -43,8 +43,8 @@
   </div>
 
   <div>
-    <%= form.label :rental_duration_sec, style: "display: block" %>
-    <%= form.number_field :rental_duration_sec %>
+    <%= form.label :rental_duration_days, style: "display: block" %>
+    <%= form.number_field :rental_duration_days %>
   </div>
 
   <div>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -37,7 +37,7 @@
 
   <p>
     <strong>Rental duration sec:</strong>
-    <%= item.rental_duration_sec %>
+    <%= item.rental_duration_days %>
   </p>
 
   <p>

--- a/app/views/items/_item.json.jbuilder
+++ b/app/views/items/_item.json.jbuilder
@@ -1,4 +1,4 @@
-json.extract! item, :id, :name, :category, :location, :description, :image, :price_ct, :rental_duration_sec,
+json.extract! item, :id, :name, :category, :location, :description, :image, :price_ct, :rental_duration_days,
               :rental_start, :return_checklist, :created_at, :updated_at
 json.url item_url(item, format: :json)
 json.image url_for(item.image)

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -162,8 +162,8 @@
     <div class="notBorderedInput">
     <%= form.collection_select(:owner_id, User.all, :id, :email, :include_blank => true, :selected => @owner_id)%>
     </div>
-    <p class="subtitle"><%= t('views.edit_item.rental_duration_sec')%></p>
-    <%= form.number_field :rental_duration_sec, class: "borderedInput body1" %>    
+    <p class="subtitle"><%= t('views.edit_item.rental_duration_days')%></p>
+    <%= form.number_field :rental_duration_days, class: "borderedInput body1" %>    
     <%= form.submit class: "btn-primary" %>
   </div>
   </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -189,8 +189,8 @@ function readURL(input) {
         <p class="subtitle"><%= t('views.edit_item.price_ct')%></p>
         <%= form.number_field :price_ct, class: "borderedInput body1" %>
 
-        <p class="subtitle"><%= t('views.edit_item.rental_duration_sec')%></p>
-        <%= form.number_field :rental_duration_sec, class: "borderedInput body1" %>
+        <p class="subtitle"><%= t('views.edit_item.rental_duration_days')%></p>
+        <%= form.number_field :rental_duration_days, class: "borderedInput body1" %>
 
         <p class="subtitle"><%= t('views.edit_item.return_checklist')%></p>
         <%= form.text_area :return_checklist, class: "borderedInput body1" %> 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -136,7 +136,7 @@
         <p class="subtitle"><%= t('views.show_item.owner')%></p>
         <p class="body-1"><%= @item.owning_user.email %></p>
         <p class="subtitle"><%= t('views.show_item.lend_until')%></p>
-        <p class="body-1"><%= ((@item.rental_start.nil? ? Time.now() : @item.rental_start) + (@item.rental_duration_sec.nil? ? 86400 : @item.rental_duration_sec*86400)).strftime('%d.%m.%Y') %></p>
+        <p class="body-1"><%= ((@item.rental_start.nil? ? Time.now() : @item.rental_start) + (@item.rental_duration_days.nil? ? 86400 : @item.rental_duration_days*86400)).strftime('%d.%m.%Y') %></p>
         <p class="subtitle"><%= t('views.show_item.waitlist')%></p>
         <p class="body-1">
           <% if !current_user.nil? %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -136,7 +136,7 @@
         <p class="subtitle"><%= t('views.show_item.owner')%></p>
         <p class="body-1"><%= @item.owning_user.email %></p>
         <p class="subtitle"><%= t('views.show_item.lend_until')%></p>
-        <p class="body-1"><%= ((@item.rental_start.nil? ? Time.now() : @item.rental_start) + (@item.rental_duration_sec.nil? ? 86400 : @item.rental_duration_sec)).strftime('%d.%m.%Y') %></p>
+        <p class="body-1"><%= ((@item.rental_start.nil? ? Time.now() : @item.rental_start) + (@item.rental_duration_sec.nil? ? 86400 : @item.rental_duration_sec*86400)).strftime('%d.%m.%Y') %></p>
         <p class="subtitle"><%= t('views.show_item.waitlist')%></p>
         <p class="body-1">
           <% if !current_user.nil? %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -112,7 +112,7 @@ de:
       pending_return_request: "Warten auf Rückgabebestätigung"
       confirm_pickup: "Abholung bestätigen"
     edit_item:
-      rental_duration_sec: "Ausleihdauer (Sekunden)"
+      rental_duration_sec: "Ausleihdauer (Tagen)"
     profile:
       title: "Profil"
       roles: "Rollen"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -112,7 +112,7 @@ de:
       pending_return_request: "Warten auf Rückgabebestätigung"
       confirm_pickup: "Abholung bestätigen"
     edit_item:
-      rental_duration_sec: "Ausleihdauer (Tagen)"
+      rental_duration_days: "Ausleihdauer (Tagen)"
     profile:
       title: "Profil"
       roles: "Rollen"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -116,7 +116,7 @@ de:
       pending_return_request: "Warten auf Rückgabebestätigung"
       confirm_pickup: "Abholung bestätigen"
     edit_item:
-      rental_duration_days: "Ausleihdauer (Tagen)"
+      rental_duration_days: "Maximale Ausleihdauer in Tagen"
     profile:
       title: "Profil"
       roles: "Rollen"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,7 +147,7 @@ en:
       pending_return_request: "Waiting for return approval"
       confirm_pickup: "Confirm pickup"
     edit_item:
-      rental_duration_days: "Rental Duration (days)"
+      rental_duration_days: "Maximum rental duration in days"
     profile:
       title: "Profile"
       roles: "Roles"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,7 +143,7 @@ en:
       pending_return_request: "Waiting for return approval"
       confirm_pickup: "Confirm pickup"
     edit_item:
-      rental_duration_sec: "Rental Duration (seconds)"
+      rental_duration_sec: "Rental Duration (days)"
     profile:
       title: "Profile"
       roles: "Roles"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,7 +143,7 @@ en:
       pending_return_request: "Waiting for return approval"
       confirm_pickup: "Confirm pickup"
     edit_item:
-      rental_duration_sec: "Rental Duration (days)"
+      rental_duration_days: "Rental Duration (days)"
     profile:
       title: "Profile"
       roles: "Roles"

--- a/db/migrate/20221118143207_create_items.rb
+++ b/db/migrate/20221118143207_create_items.rb
@@ -6,7 +6,7 @@ class CreateItems < ActiveRecord::Migration[7.0]
       t.string :location
       t.text :description
       t.integer :price_ct
-      t.integer :rental_duration_sec
+      t.integer :rental_duration_days
       t.timestamp :rental_start
       t.text :return_checklist
 

--- a/db/migrate/20230115113230_rename_items_column_rental_duration_sec.rb
+++ b/db/migrate/20230115113230_rename_items_column_rental_duration_sec.rb
@@ -1,0 +1,5 @@
+class RenameItemsColumnRentalDurationSec < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :items, :rental_duration_days, :rental_duration_days
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_06_180533) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_15_113230) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_180533) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
+    t.integer "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -58,7 +58,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_180533) do
     t.string "location"
     t.text "description"
     t.integer "price_ct"
-    t.integer "rental_duration_sec"
+    t.integer "rental_duration_days"
     t.datetime "rental_start", precision: nil
     t.text "return_checklist"
     t.datetime "created_at", null: false

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     description { "MyDescription" }
     image { Rack::Test::UploadedFile.new('spec/testimages/test_image.png', 'image/png') }
     price_ct { 1 }
-    rental_duration_sec { 1 }
+    rental_duration_days { 1 }
     rental_start { "2022-11-18 15:32:07" }
     return_checklist { "MyChecklist" }
     lend_status { :available }
@@ -19,7 +19,7 @@ FactoryBot.define do
     description { "MyDescription" }
     image { Rack::Test::UploadedFile.new('spec/testimages/test_image.png', 'image/png') }
     price_ct { 1 }
-    rental_duration_sec { 1 }
+    rental_duration_days { 1 }
     rental_start { "2022-11-18 15:32:07" }
     return_checklist { "MyChecklist" }
     lend_status { :available }
@@ -32,7 +32,7 @@ FactoryBot.define do
     description { "MyDescription" }
     image { Rack::Test::UploadedFile.new('spec/testimages/test_image.png', 'image/png') }
     price_ct { 1 }
-    rental_duration_sec { 1 }
+    rental_duration_days { 1 }
     rental_start { "2022-11-18 15:32:07" }
     return_checklist { "MyChecklist" }
     lend_status { :pending_return }
@@ -45,7 +45,7 @@ FactoryBot.define do
     description { "MyDescription" }
     image { Rack::Test::UploadedFile.new('spec/testimages/test_image.png', 'image/png') }
     price_ct { 1 }
-    rental_duration_sec { 1 }
+    rental_duration_days { 1 }
     rental_start { "2022-11-18 15:32:07" }
     return_checklist { "MyChecklist" }
     lend_status { :lent }
@@ -59,7 +59,7 @@ FactoryBot.define do
     description { "MyDescription" }
     image { Rack::Test::UploadedFile.new('spec/testimages/test_image.png', 'image/png') }
     price_ct { 1 }
-    rental_duration_sec { 1 }
+    rental_duration_days { 1 }
     rental_start { "2022-11-18 15:32:07" }
     return_checklist { "MyChecklist" }
     lend_status { :pending_return }
@@ -73,7 +73,7 @@ FactoryBot.define do
     description { "Useful book for all who want to dive deeper" }
     image { nil }
     price_ct { 10_000 }
-    rental_duration_sec { 60 * 60 * 24 * 7 }
+    rental_duration_days { 60 * 60 * 24 * 7 }
     rental_start { "2022-11-18 15:32:07" }
     return_checklist { "Close the book. Remove sticky notes." }
     lend_status { :lent }
@@ -86,7 +86,7 @@ FactoryBot.define do
     description { "Very small but powerful beamer to use during presentations. Also suitable for watching films." }
     image { nil }
     price_ct { 100 }
-    rental_duration_sec { 60 * 60 * 3 }
+    rental_duration_days { 60 * 60 * 3 }
     rental_start { "2022-11-21 15:32:07" }
     return_checklist { "Turn off the beamer." }
     lend_status { :pending_return }
@@ -99,7 +99,7 @@ FactoryBot.define do
     description { "Standard Whiteboard with lots of space for innovative ideas." }
     image { nil }
     price_ct { 500 }
-    rental_duration_sec { 60 * 60 * 5 }
+    rental_duration_days { 60 * 60 * 5 }
     rental_start { "2022-10-10 3:14:15" }
     return_checklist { "Clean the whiteboard." }
     owning_user { create(:user) }
@@ -112,7 +112,7 @@ FactoryBot.define do
     description { "Standard Whiteboard with lots of space for innovative ideas." }
     image { Rack::Test::UploadedFile.new('spec/testimages/test_image.png', 'image/png') }
     price_ct { 500 }
-    rental_duration_sec { nil }
+    rental_duration_days { nil }
     rental_start { nil }
     return_checklist { "Clean the whiteboard." }
     owning_user { create(:user) }

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -73,7 +73,7 @@ FactoryBot.define do
     description { "Useful book for all who want to dive deeper" }
     image { nil }
     price_ct { 10_000 }
-    rental_duration_days { 60 * 60 * 24 * 7 }
+    rental_duration_days { 7 }
     rental_start { "2022-11-18 15:32:07" }
     return_checklist { "Close the book. Remove sticky notes." }
     lend_status { :lent }
@@ -86,7 +86,7 @@ FactoryBot.define do
     description { "Very small but powerful beamer to use during presentations. Also suitable for watching films." }
     image { nil }
     price_ct { 100 }
-    rental_duration_days { 60 * 60 * 3 }
+    rental_duration_days { 1 }
     rental_start { "2022-11-21 15:32:07" }
     return_checklist { "Turn off the beamer." }
     lend_status { :pending_return }
@@ -99,7 +99,7 @@ FactoryBot.define do
     description { "Standard Whiteboard with lots of space for innovative ideas." }
     image { nil }
     price_ct { 500 }
-    rental_duration_days { 60 * 60 * 5 }
+    rental_duration_days { 1 }
     rental_start { "2022-10-10 3:14:15" }
     return_checklist { "Clean the whiteboard." }
     owning_user { create(:user) }

--- a/spec/features/dashboard/lent_items_spec.rb
+++ b/spec/features/dashboard/lent_items_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Lent Items", type: :feature do
     @owner = create(:user)
     @user = create(:user)
     item = create(:item, owning_user: @owner, holder: @user.id, rental_start: Time.now.utc,
-                         rental_duration_sec: 86_400)
+                         rental_duration_days: 1)
     sign_in @user
     visit dashboard_path
     expect(page).to have_content(item.name)
@@ -36,8 +36,8 @@ RSpec.describe "Lent Items", type: :feature do
   it "shows the correct tag for lent items which are overdue" do
     @owner = create(:user)
     @user = create(:user)
-    item = create(:item, owning_user: @owner, holder: @user.id, rental_start: Time.now.utc - 10.seconds,
-                         rental_duration_sec: 5)
+    item = create(:item, owning_user: @owner, holder: @user.id, rental_start: Time.now.utc - 2.days.seconds,
+                         rental_duration_days: 1)
     sign_in @user
     visit dashboard_path
     expect(page).to have_content(item.name)

--- a/spec/features/dashboard/offered_items_spec.rb
+++ b/spec/features/dashboard/offered_items_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe "Offered Items", type: :feature do
   it "shows the correct tag for offered items which are overdue" do
     @user = create(:user)
     @borrower = create(:user)
-    item = create(:item, owning_user: @user, holder: @borrower.id, rental_start: Time.now.utc - 10.seconds,
-                         rental_duration_sec: 5)
+    item = create(:item, owning_user: @user, holder: @borrower.id, rental_start: Time.now.utc - 2.days.seconds,
+                         rental_duration_days: 1)
     sign_in @user
     visit dashboard_path
     expect(page).to have_content(item.name)

--- a/spec/features/dashboard/progress_bar_spec.rb
+++ b/spec/features/dashboard/progress_bar_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Progress Bar under Lent items", type: :feature do
     @owner = create(:user)
     @user = create(:user)
     item = create(:item, owning_user: @owner, holder: @user.id, rental_start: Time.now.utc,
-                         rental_duration_days: 86_400)
+                         rental_duration_days: 1)
     sign_in @user
     visit dashboard_path
     expect(page).to have_content(item.name)
@@ -40,7 +40,7 @@ RSpec.describe "Progress Bar under Lent items", type: :feature do
   it "displays the progess as 50 if the remaining rental duration is half of the original rental duration" do
     @owner = create(:user)
     @user = create(:user)
-    item = create(:item, owning_user: @owner, holder: @user.id, rental_duration_days: 172_800,
+    item = create(:item, owning_user: @owner, holder: @user.id, rental_duration_days: 2,
                          rental_start: Time.now.utc - 1.day)
     sign_in @user
     visit dashboard_path

--- a/spec/features/dashboard/progress_bar_spec.rb
+++ b/spec/features/dashboard/progress_bar_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe "Progress Bar under Lent items", type: :feature do
   it "displays the progess as 0 if the rental start is now" do
     @owner = create(:user)
     @user = create(:user)
-    item = create(:item, owning_user: @owner, holder: @user.id, rental_start: Time.now.utc, rental_duration_sec: 86_400)
+    item = create(:item, owning_user: @owner, holder: @user.id, rental_start: Time.now.utc,
+                         rental_duration_days: 86_400)
     sign_in @user
     visit dashboard_path
     expect(page).to have_content(item.name)
@@ -29,7 +30,7 @@ RSpec.describe "Progress Bar under Lent items", type: :feature do
   it "displays the progess as 100 if the remaining rental duration is zero" do
     @owner = create(:user)
     @user = create(:user)
-    item = create(:item, owning_user: @owner, holder: @user.id, rental_duration_sec: 0)
+    item = create(:item, owning_user: @owner, holder: @user.id, rental_duration_days: 0)
     sign_in @user
     visit dashboard_path
     expect(page).to have_content(item.name)
@@ -39,7 +40,7 @@ RSpec.describe "Progress Bar under Lent items", type: :feature do
   it "displays the progess as 50 if the remaining rental duration is half of the original rental duration" do
     @owner = create(:user)
     @user = create(:user)
-    item = create(:item, owning_user: @owner, holder: @user.id, rental_duration_sec: 172_800,
+    item = create(:item, owning_user: @owner, holder: @user.id, rental_duration_days: 172_800,
                          rental_start: Time.now.utc - 1.day)
     sign_in @user
     visit dashboard_path
@@ -60,7 +61,7 @@ RSpec.describe "Progress Bar under Lent items", type: :feature do
   it "displays the progess as 100 if the remaining rental duration is nil" do
     @owner = create(:user)
     @user = create(:user)
-    item = create(:item, owning_user: @owner, holder: @user.id, rental_duration_sec: nil)
+    item = create(:item, owning_user: @owner, holder: @user.id, rental_duration_days: nil)
     sign_in @user
     visit dashboard_path
     expect(page).to have_content(item.name)

--- a/spec/views/items/edit.html.erb_spec.rb
+++ b/spec/views/items/edit.html.erb_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "items/edit", type: :view do
 
       assert_select "input[name=?]", "item[image]"
 
-      assert_select "input[name=?]", "item[rental_duration_sec]"
+      assert_select "input[name=?]", "item[rental_duration_days]"
 
       assert_select "select[name=?]", "item[owner_id]"
 

--- a/spec/views/items/new.html.erb_spec.rb
+++ b/spec/views/items/new.html.erb_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "items/new", type: :view do
 
       assert_select "input[name=?]", "item[price_ct]"
 
-      assert_select "input[name=?]", "item[rental_duration_sec]"
+      assert_select "input[name=?]", "item[rental_duration_days]"
 
       assert_select "textarea[name=?]", "item[return_checklist]"
 


### PR DESCRIPTION
Fixes #220 

The user should be able to enter the rental duration in days instead of seconds.
- Changed name attribute rental_duration_sec to rental_duration_name. Thus the schema was changed and a migration was created
- The operations that have to do with the rental duration are still done in seconds (it is easier this way given how operations are implemented in the Time class)
- Also modified some tests, that failed after the changes

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [ ] another dev reviewed and approved
- [ ] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
