### PR TITLE
Fixes the sign out button for heroku

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,4 +30,8 @@ class ApplicationController < ActionController::Base
   rescue StandardError
     I18n.default_locale
   end
+
+  def after_sign_out_path_for(_resource_or_scope)
+    new_user_session_path
+  end
 end


### PR DESCRIPTION
Fixes #245 

Description: The sign out button did not automatically redirect to the login page on heroku. This pull request should fix this.

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
