### PR TITLE
Feature/ap 248 item popularity

### DIFF
--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -2,6 +2,9 @@ module StatisticsHelper
   # Module for generating and collecting statistics.
   # Please let your helper function start with "statistics_"
 
+  # Please keep the documentaion up to date:
+  # https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Statistics
+
   def statistics_item_popularity(item)
     lend_events = item_lend_events(item)
     return_events = item_return_events(item)

--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -1,4 +1,37 @@
 module StatisticsHelper
   # Module for generating and collecting statistics.
   # Please let your helper function start with "statistics_"
+
+  def statistics_item_popularity(item)
+    lend_events = item_lend_events(item)
+    return_events = item_return_events(item)
+    avg_lend_duration = average_lend_duration(lend_events, return_events)
+
+    # add 1 to every factor to avoid the result being 0
+    ((lend_events.length + 1) * (avg_lend_duration + 1) *
+    (item.waitlist_length + 1)) / (item.age.nonzero? or 1)
+  end
+
+  private
+
+  def item_lend_events(item)
+    AuditEvent.where(
+      item: item,
+      event_type: :accept_lend
+    ).order(created_at: :asc)
+  end
+
+  def item_return_events(item)
+    AuditEvent.where(
+      item: item,
+      event_type: :accept_return
+    ).order(created_at: :asc)
+  end
+
+  def average_lend_duration(lend_events, return_events)
+    durations = lend_events.zip(return_events)
+                           .delete_if { |l, r| l.nil? or r.nil? }
+                           .collect { |l, r| (r.created_at - l.created_at).seconds }
+    durations.sum / (durations.size.nonzero? or 1)
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -179,5 +179,15 @@ class Item < ApplicationRecord
       lent_time_progress
     end
   end
+
+  def age
+    Time.current.to_i - created_at.to_i
+  end
+
+  def waitlist_length
+    return 0 if waitlist.nil?
+
+    waitlist.users.length
+  end
 end
 # rubocop:enable Metrics/ClassLength

--- a/spec/factories/audit_events.rb
+++ b/spec/factories/audit_events.rb
@@ -1,9 +1,8 @@
 FactoryBot.define do
-  factory :audit_event do
+  factory :audit_event, class: 'AuditEvent' do
     item { nil }
-    owner { nil }
     holder { nil }
-    triggering_user { nil }
+    triggering_user { create(:user) }
     event_type { 1 }
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -156,7 +156,7 @@ FactoryBot.define do
     lend_status { :available }
     owning_user { create(:user) }
   end
-  
+
   factory :available_item, class: 'Item' do
     name { "AvailableItem" }
     category { "book" }
@@ -169,7 +169,7 @@ FactoryBot.define do
     lend_status { :available }
     owning_user { create(:user) }
   end
-  
+
   factory :lent_item, class: 'Item' do
     name { "LentItem" }
     category { "book" }

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -117,4 +117,43 @@ FactoryBot.define do
     return_checklist { "Clean the whiteboard." }
     owning_user { create(:user) }
   end
+
+  factory :itemAudited0, class: 'Item' do
+    id { 42_420 }
+    name { "AuditedItem0" }
+    category { "Books" }
+    location { "D-Space" }
+    description { "An audited item" }
+    image { nil }
+    price_ct { 42 }
+    rental_duration_sec { 42 }
+    lend_status { :available }
+    owning_user { create(:user) }
+  end
+
+  factory :itemAudited1, class: 'Item' do
+    id { 42_421 }
+    name { "AuditedItem1" }
+    category { "Books" }
+    location { "D-Space" }
+    description { "An audited item" }
+    image { nil }
+    price_ct { 42 }
+    rental_duration_sec { 42 }
+    lend_status { :available }
+    owning_user { create(:user) }
+  end
+
+  factory :itemAudited2, class: 'Item' do
+    id { 42_422 }
+    name { "AuditedItem2" }
+    category { "Books" }
+    location { "D-Space" }
+    description { "An audited item" }
+    image { nil }
+    price_ct { 42 }
+    rental_duration_sec { 42 }
+    lend_status { :available }
+    owning_user { create(:user) }
+  end
 end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe "Search", type: :helper do
     @item_book = create(:item_book)
     @item_beamer = create(:item_beamer)
     @item_whiteboard = create(:item_whiteboard)
+
+    @audited_items = [
+      create(:itemAudited0),
+      create(:itemAudited1),
+      create(:itemAudited2)
+    ]
   end
 
   it "Searches correctly for name" do
@@ -29,12 +35,12 @@ RSpec.describe "Search", type: :helper do
 
   it "Searches correctly for empty string" do
     results = search_for_items("")
-    expect(results.length).to be(3)
+    expect(results.length).to be(6)
   end
 
   it "Searches correctly for string only with whitespaces" do
     results = search_for_items("   ")
-    expect(results.length).to be(3)
+    expect(results.length).to be(6)
   end
 
   it "Searches correctly for both items with 'to'" do
@@ -96,6 +102,24 @@ RSpec.describe "Search", type: :helper do
     expect(results).not_to include(@item_book)
     expect(results).not_to include(@item_beamer)
     expect(results).to include(@item_whiteboard)
+  end
+
+  it "puts items in the correct order when sorted by popularity" do
+    @audited_items.each_with_index do |item, index|
+      ((index + 1) * 10).times do
+        create(:audit_event,
+               item: item,
+               event_type: :accept_lend)
+        create(:audit_event,
+               item: item,
+               event_type: :accept_return)
+      end
+    end
+    @audited_items.take(@audited_items.size - 1)
+                  .zip(@audited_items.drop(1))
+                  .collect do |first_item, second_item|
+      expect(helper.statistics_item_popularity(first_item)).to be <= helper.statistics_item_popularity(second_item)
+    end
   end
 
 end


### PR DESCRIPTION
Fixes #248 

The item popularity statistic is now implemented. See [Wiki](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Statistics).

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
