### PR TITLE
* Adds "Waiting For..." to the dashboard

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -108,6 +108,10 @@ class Item < ApplicationRecord
     waitlist.remove_user(user)
   end
 
+  def waitlist_contains(user)
+    !(waitlist.nil? || waitlist.position(user).nil?)
+  end
+
   def users_with_see_permission
     users_with_direct_see_permission + users_with_indirect_see_permission
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,6 +83,10 @@ class User < ApplicationRecord
     directly_owned_items + indirectly_owned_items
   end
 
+  def waitlists
+    waitlists
+  end
+
   def self.from_omniauth(auth)
     # Create user in database if it does not exist yet when logging in via OIDC
     where(email: auth.info.email).first_or_create! do |user|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,10 +83,6 @@ class User < ApplicationRecord
     directly_owned_items + indirectly_owned_items
   end
 
-  def waitlists
-    waitlists
-  end
-
   def self.from_omniauth(auth)
     # Create user in database if it does not exist yet when logging in via OIDC
     where(email: auth.info.email).first_or_create! do |user|

--- a/app/views/dashboard/_waitlist.html.erb
+++ b/app/views/dashboard/_waitlist.html.erb
@@ -1,0 +1,18 @@
+<div>
+  <% items = Item.all %>
+  <% items = items.select {|item| item.waitlist_contains(current_user)}%>
+  <% items = items.sort_by { |item| [item.waitlist.position(current_user), item.name] } %>
+  <% if items.empty? %>
+    <p class="body-1"><%= t 'views.dashboard.waitlist.nowhere_on_waitlists' %></p>
+  <% else %>
+    <div class="container">
+      <div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-lg-5 row-cols-xl-6 g-4">
+        <% items.each do |item| %>
+          <div>
+            <%= render :partial => "partials/itemcard", :locals => { :item => item } %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/dashboard/_waitlist.html.erb
+++ b/app/views/dashboard/_waitlist.html.erb
@@ -10,6 +10,7 @@
         <% items.each do |item| %>
           <div>
             <%= render :partial => "partials/itemcard", :locals => { :item => item } %>
+            <p class="<% if item.waitlist.first_user.eql?(current_user) %> caption-primary <% else %> caption <% end %>  text-center"> <%= t 'views.dashboard.waitlist.position', position: item.waitlist.position(current_user) + 1 %> </p>
           </div>
         <% end %>
       </div>

--- a/app/views/dashboard/_waitlist.html.erb
+++ b/app/views/dashboard/_waitlist.html.erb
@@ -1,6 +1,5 @@
 <div>
-  <% items = Item.all %>
-  <% items = items.select {|item| item.waitlist_contains(current_user)}%>
+  <% items = current_user.waitlists.map{|waitlist| waitlist.item }%>
   <% items = items.sort_by { |item| [item.waitlist.position(current_user), item.name] } %>
   <% if items.empty? %>
     <p class="body-1"><%= t 'views.dashboard.waitlist.nowhere_on_waitlists' %></p>

--- a/app/views/dashboard/_waitlist.html.erb
+++ b/app/views/dashboard/_waitlist.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <% items = current_user.waitlists.map{|waitlist| waitlist.item }%>
+  <% items = current_user.waitlists.map { |waitlist| waitlist.item } %>
   <% items = items.sort_by { |item| [item.waitlist.position(current_user), item.name] } %>
   <% if items.empty? %>
     <p class="body-1"><%= t 'views.dashboard.waitlist.nowhere_on_waitlists' %></p>
@@ -9,7 +9,7 @@
         <% items.each do |item| %>
           <div>
             <%= render :partial => "partials/itemcard", :locals => { :item => item } %>
-            <p class="<% if item.waitlist.first_user.eql?(current_user) %> caption-primary <% else %> caption <% end %>  text-center"> <%= t 'views.dashboard.waitlist.position', position: item.waitlist.position(current_user) + 1 %> </p>
+            <p class="<% if item.waitlist.first_user.eql?(current_user) %> caption-primary <% else %> caption <% end %>  text-center"> <%= t 'views.dashboard.waitlist.position', position: item.waitlist.position(current_user) + 1 %></p>
           </div>
         <% end %>
       </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -8,5 +8,8 @@
 <h3 class="subtitle mt-1"><%= t 'views.dashboard.offered_items.title' %></h3>
     <%= render "offered_items"%>
 
+<h3 class="subtitle mt-1"><%= t 'views.dashboard.waitlist.title' %></h3>
+<%= render "waitlist"%>
+
 <h3 class="subtitle mt-1"><%= t 'views.dashboard.favorites.title' %></h3>
     <%= render "favorites"%>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -11,5 +11,5 @@
 <h3 class="subtitle mt-1"><%= t 'views.dashboard.waitlist.title' %></h3>
 <%= render "waitlist"%>
 
-<h3 class="subtitle mt-1"><%= t 'views.dashboard.favorites.title' %></h3>
+<h3 class="subtitle mt-2"><%= t 'views.dashboard.favorites.title' %></h3>
     <%= render "favorites"%>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -40,6 +40,9 @@ de:
         lent: "Ausgeliehen"
         not_lent: "Nicht ausgeliehen"
         overdue: "Überfällig"
+      waitlist:
+        title: "WARTEND AUF ..."
+        nowhere_on_waitlists: "Aktuell wartest du auf keine Artikel."
       favorites:
         title: "DEINE MERKLISTE"
         missing_favorites: "Aktuell hast du keine gespeicherten Artikel."

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -43,6 +43,7 @@ de:
       waitlist:
         title: "WARTEND AUF ..."
         nowhere_on_waitlists: "Aktuell wartest du auf keine Artikel."
+        position: "Wartelistenposition: %{position}"
       favorites:
         title: "DEINE MERKLISTE"
         missing_favorites: "Aktuell hast du keine gespeicherten Artikel."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,9 @@ en:
         lent: "Lent"
         not_lent: "Not lent"
         overdue: "Overdue"
+      waitlist:
+        title: "WAITING FOR ..."
+        nowhere_on_waitlists: "Currently, you are not waiting for any items."
       favorites:
         title: "YOUR FAVORITES"
         missing_favorites: "Currently, you have no favored items."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,6 +74,7 @@ en:
       waitlist:
         title: "WAITING FOR ..."
         nowhere_on_waitlists: "Currently, you are not waiting for any items."
+        position: "Waitlist Position: %{position}"
       favorites:
         title: "YOUR FAVORITES"
         missing_favorites: "Currently, you have no favored items."

--- a/spec/factories/waitlists.rb
+++ b/spec/factories/waitlists.rb
@@ -6,4 +6,8 @@ FactoryBot.define do
     users { [ build(:user), build(:max) ] }
     item { build(:item) }
   end
+  factory :waitlist_with_one_waiter, class: 'Waitlist' do
+    users { [ build(:max) ] }
+    item { build(:item) }
+  end
 end

--- a/spec/factories/waitlists.rb
+++ b/spec/factories/waitlists.rb
@@ -6,8 +6,7 @@ FactoryBot.define do
     users { [ build(:user), build(:max) ] }
     item { build(:item) }
   end
-  factory :waitlist_with_one_waiter, class: 'Waitlist' do
-    users { [ build(:max) ] }
+  factory :empty_waitlist, class: 'Waitlist' do
     item { build(:item) }
   end
 end

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe "Dashboard", type: :feature do
     expect(page).to have_content I18n.t('views.dashboard.offered_items.title')
   end
 
+  it "shows what items you are waiting for" do
+    sign_in user
+    visit dashboard_path
+    expect(page).to have_content I18n.t('views.dashboard.waitlist.title')
+  end
+
   it "shows favorites" do
     sign_in user
     visit dashboard_path

--- a/spec/features/dashboard/waitlist_view_spec.rb
+++ b/spec/features/dashboard/waitlist_view_spec.rb
@@ -15,21 +15,13 @@ RSpec.describe "Waitlist View", type: :feature do
     item_lent.waitlist.add_user(user)
     visit dashboard_path
     expect(page).to have_content(item_lent.name)
+    expect(page).to have_content I18n.t 'views.dashboard.waitlist.position',
+                                        position: (item_lent.waitlist.position(user) + 1)
   end
 
   it "shows message when you are not waiting for any items" do
     sign_in user
     visit dashboard_path
     expect(page).to have_content I18n.t('views.dashboard.waitlist.nowhere_on_waitlists')
-  end
-
-  it "shows the position in the waitlist as a tag" do
-    sign_in user
-    item_lent.waitlist.add_user(user)
-    visit item_path(item_lent)
-    find(:button, "Show waitlist").click
-    visit dashboard_path
-    expect(page).to have_content I18n.t 'views.dashboard.waitlist.position',
-                                        position: (item_lent.waitlist.position(user) + 1)
   end
 end

--- a/spec/features/dashboard/waitlist_view_spec.rb
+++ b/spec/features/dashboard/waitlist_view_spec.rb
@@ -5,17 +5,11 @@ RSpec.describe "Waitlist View", type: :feature do
   let(:owner) { create(:user) }
   let(:user) { create(:user) }
   let(:borrower) { create(:user) }
-  let(:item) do
-    item = create(:item, owning_user: owner)
-    item.waitlist = create(:waitlist_with_item)
-    item.waitlist.item = item
-    item
-  end
+
   let(:item_lent) do
     item_lent = create(:lent, owning_user: owner, holder: borrower.id)
     item_lent.waitlist = create(:waitlist_with_item)
     item_lent.waitlist.item = item_lent
-    item_lent
   end
 
   it "shows item you are waiting for" do
@@ -30,5 +24,14 @@ RSpec.describe "Waitlist View", type: :feature do
     sign_in user
     visit dashboard_path
     expect(page).to have_content I18n.t('views.dashboard.waitlist.nowhere_on_waitlists')
+  end
+
+  it "shows the position in the waitlist as a tag" do
+    sign_in user
+    visit item_path(item_lent)
+    expect(page).to have_content I18n.t('views.show_item.users_waiting', amount: 2)
+    find(:button, "Enter Waitlist").click
+    visit dashboard_path
+    expect(page).to have_content I18n.t('views.dashboard.waitlist.position', position: 3)
   end
 end

--- a/spec/features/dashboard/waitlist_view_spec.rb
+++ b/spec/features/dashboard/waitlist_view_spec.rb
@@ -27,6 +27,6 @@ RSpec.describe "Waitlist View", type: :feature do
     sign_in user
     item_lent.waitlist.add_user(user)
     visit dashboard_path
-    expect(page).to have_content I18n.t('views.dashboard.waitlist.position', position: 3)
+    expect(page).to have_content I18n.t('views.dashboard.waitlist.position', position: item_lent.waitlist.position(user) + 1)
   end
 end

--- a/spec/features/dashboard/waitlist_view_spec.rb
+++ b/spec/features/dashboard/waitlist_view_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "Waitlist View", type: :feature do
     sign_in user
     item_lent.waitlist.add_user(user)
     visit dashboard_path
-    expect(page).to have_content I18n.t('views.dashboard.waitlist.position', position: item_lent.waitlist.position(user) + 1)
+    expect(page).to have_content I18n.t('views.dashboard.waitlist.position',
+                                        position: item_lent.waitlist.position(user) + 1)
   end
 end

--- a/spec/features/dashboard/waitlist_view_spec.rb
+++ b/spec/features/dashboard/waitlist_view_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe "Waitlist View", type: :feature do
     sign_in user
     item_lent.waitlist.add_user(user)
     visit dashboard_path
-    expect(page).to have_content I18n.t 'views.dashboard.waitlist.position',
-                                        position: (item_lent.waitlist.position(user) + 1)
+    expect(page).to have_content I18n.t 'views.dashboard.waitlist.position', position: 1
   end
 end

--- a/spec/features/dashboard/waitlist_view_spec.rb
+++ b/spec/features/dashboard/waitlist_view_spec.rb
@@ -2,20 +2,17 @@ require "rails_helper"
 
 RSpec.describe "Waitlist View", type: :feature do
 
-  let(:owner) { create(:user) }
   let(:user) { create(:user) }
-  let(:borrower) { create(:user) }
 
   let(:item_lent) do
-    item_lent = create(:lent, owning_user: owner, holder: borrower.id)
+    item_lent = create(:item)
     item_lent.waitlist = create(:waitlist_with_item)
     item_lent.waitlist.item = item_lent
   end
 
   it "shows item you are waiting for" do
     sign_in user
-    visit item_path(item_lent)
-    find(:button, "Enter Waitlist").click
+    item_lent.waitlist.add_user(user)
     visit dashboard_path
     expect(page).to have_content(item_lent.name)
   end
@@ -28,9 +25,7 @@ RSpec.describe "Waitlist View", type: :feature do
 
   it "shows the position in the waitlist as a tag" do
     sign_in user
-    visit item_path(item_lent)
-    expect(page).to have_content I18n.t('views.show_item.users_waiting', amount: 2)
-    find(:button, "Enter Waitlist").click
+    item_lent.waitlist.add_user(user)
     visit dashboard_path
     expect(page).to have_content I18n.t('views.dashboard.waitlist.position', position: 3)
   end

--- a/spec/features/dashboard/waitlist_view_spec.rb
+++ b/spec/features/dashboard/waitlist_view_spec.rb
@@ -26,7 +26,10 @@ RSpec.describe "Waitlist View", type: :feature do
   it "shows the position in the waitlist as a tag" do
     sign_in user
     item_lent.waitlist.add_user(user)
+    visit item_path(item_lent)
+    find(:button, "Show waitlist").click
     visit dashboard_path
-    expect(page).to have_content I18n.t('views.dashboard.waitlist.position', position: 2)
+    expect(page).to have_content I18n.t 'views.dashboard.waitlist.position',
+                                        position: (item_lent.waitlist.position(user) + 1)
   end
 end

--- a/spec/features/dashboard/waitlist_view_spec.rb
+++ b/spec/features/dashboard/waitlist_view_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe "Waitlist View", type: :feature do
+
+  let(:owner) { create(:user) }
+  let(:user) { create(:user) }
+  let(:borrower) { create(:user) }
+  let(:item) do
+    item = create(:item, owning_user: owner)
+    item.waitlist = create(:waitlist_with_item)
+    item.waitlist.item = item
+    item
+  end
+  let(:item_lent) do
+    item_lent = create(:lent, owning_user: owner, holder: borrower.id)
+    item_lent.waitlist = create(:waitlist_with_item)
+    item_lent.waitlist.item = item_lent
+    item_lent
+  end
+
+  it "shows item you are waiting for" do
+    sign_in user
+    visit item_path(item_lent)
+    find(:button, "Enter Waitlist").click
+    visit dashboard_path
+    expect(page).to have_content(item_lent.name)
+  end
+
+  it "shows message when you are not waiting for any items" do
+    sign_in user
+    visit dashboard_path
+    expect(page).to have_content I18n.t('views.dashboard.waitlist.nowhere_on_waitlists')
+  end
+end

--- a/spec/features/dashboard/waitlist_view_spec.rb
+++ b/spec/features/dashboard/waitlist_view_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Waitlist View", type: :feature do
 
   let(:item_lent) do
     item_lent = create(:item)
-    item_lent.waitlist = create(:waitlist_with_one_waiter)
+    item_lent.waitlist = create(:empty_waitlist)
     item_lent.waitlist.item = item_lent
   end
 
@@ -15,13 +15,19 @@ RSpec.describe "Waitlist View", type: :feature do
     item_lent.waitlist.add_user(user)
     visit dashboard_path
     expect(page).to have_content(item_lent.name)
-    expect(page).to have_content I18n.t 'views.dashboard.waitlist.position',
-                                        position: (item_lent.waitlist.position(user) + 1)
   end
 
   it "shows message when you are not waiting for any items" do
     sign_in user
     visit dashboard_path
     expect(page).to have_content I18n.t('views.dashboard.waitlist.nowhere_on_waitlists')
+  end
+
+  it "shows the position in the waitlist as a tag" do
+    sign_in user
+    item_lent.waitlist.add_user(user)
+    visit dashboard_path
+    expect(page).to have_content I18n.t 'views.dashboard.waitlist.position',
+                                        position: (item_lent.waitlist.position(user) + 1)
   end
 end

--- a/spec/features/dashboard/waitlist_view_spec.rb
+++ b/spec/features/dashboard/waitlist_view_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Waitlist View", type: :feature do
 
   let(:item_lent) do
     item_lent = create(:item)
-    item_lent.waitlist = create(:waitlist_with_item)
+    item_lent.waitlist = create(:waitlist_with_one_waiter)
     item_lent.waitlist.item = item_lent
   end
 
@@ -27,7 +27,6 @@ RSpec.describe "Waitlist View", type: :feature do
     sign_in user
     item_lent.waitlist.add_user(user)
     visit dashboard_path
-    expect(page).to have_content I18n.t('views.dashboard.waitlist.position',
-                                        position: item_lent.waitlist.position(user) + 1)
+    expect(page).to have_content I18n.t('views.dashboard.waitlist.position', position: 2)
   end
 end


### PR DESCRIPTION
Fixes #306 #307 #323

Description: 
For PO: I have changed the name of the section to be in capital letters and the message when the section is empty to "Currently, you are not waiting for any items." in order to be consistent. 

For Dev: If you have any idea on how to identify the items which have to be displayed without looking through all the existing items please inform me immediately. **(Should be solved!)**

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
