### PR TITLE
available items are now always on top of search results #319

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -20,6 +20,7 @@ module SearchHelper
     Item.where(partial_matching_clause)
         .where(categorial_attribute_clause)
         .where(numerical_attribute_clause)
+        .order(lend_status: :asc)
   end
 
   private

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -117,4 +117,30 @@ FactoryBot.define do
     return_checklist { "Clean the whiteboard." }
     owning_user { create(:user) }
   end
+
+  factory :available_item, class: 'Item' do
+    name { "AvailableItem" }
+    category { "book" }
+    location { "D-Space" }
+    description { "This item is available." }
+    image { Rack::Test::UploadedFile.new('spec/testimages/test_image.png', 'image/png') }
+    price_ct { 500 }
+    rental_duration_sec { 100 }
+    rental_start { nil }
+    lend_status { :available }
+    owning_user { create(:user) }
+  end
+
+  factory :lent_item, class: 'Item' do
+    name { "LentItem" }
+    category { "book" }
+    location { "D-Space" }
+    description { "This item is lent." }
+    image { Rack::Test::UploadedFile.new('spec/testimages/test_image.png', 'image/png') }
+    price_ct { 500 }
+    rental_duration_sec { 100 }
+    rental_start { nil }
+    lend_status { :lent }
+    owning_user { create(:user) }
+  end
 end

--- a/spec/features/search/search_spec.rb
+++ b/spec/features/search/search_spec.rb
@@ -5,6 +5,8 @@ describe "Search page", type: :feature do
     @item_book = create(:item_book)
     @item_beamer = create(:item_beamer)
     @item_whiteboard = create(:item_whiteboard)
+    @item_available = create(:available_item)
+    @item_lent = create(:lent_item)
     visit search_path
   end
 
@@ -59,6 +61,12 @@ describe "Search page", type: :feature do
     expect(page).to have_text(@item_book.name)
     expect(page).to have_text(@item_beamer.name)
     expect(page).to have_text(@item_whiteboard.name)
+  end
+
+  it "shows available items first" do
+    page.fill_in "search", with: "item"
+    click_button("submit")
+    expect(page).to have_text(/#{@item_available.name}.*\n.*#{@item_lent.name}/)
   end
 
 end


### PR DESCRIPTION
Fixes #319 

Available items are now displayed at the top of search results.

## PR checklist

- [ ] dev-branch has been merged into local branch to resolve conflicts
- [ ] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [ ] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
