### PR TITLE
Fix: sql injection search page

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -24,20 +24,20 @@ module SearchHelper
   # CREATE CLAUSE FOR PARTIAL MATCHING
 
   def create_partial_matching_attribute_term(search_attribute, search_term)
-    Item.where("LOWER( #{search_attribute} ) LIKE ?", "%" + Item.sanitize_sql_like(search_term.downcase) + "%")
+    Item.where("LOWER( #{search_attribute} ) LIKE ?", "%#{Item.sanitize_sql_like(search_term.downcase)}%")
   end
 
   def create_partial_matching_one_search_term(search_term)
     clauses = relevant_search_attributes.map do |attribute|
       create_partial_matching_attribute_term(attribute, search_term)
     end
-    clauses.inject {| joined, current | joined.or(current)}
+    clauses.inject { |joined, current| joined.or(current) }
   end
 
   def create_partial_matching_clause(search_term)
     search_terms = search_term.split
     clauses = search_terms.map { |term| create_partial_matching_one_search_term(term) }
-    clauses.inject {| joined, current | joined.and(current)}
+    clauses.inject { |joined, current| joined.and(current) }
   end
 
   # GENERATE CLAUSE FOR ATTRIBUTES
@@ -46,7 +46,7 @@ module SearchHelper
     clauses = relevant_attributes.map do |attribute|
       create_single_attribute_clause(attribute, filter, clause_generator)
     end
-    clauses.inject{| joined, current | joined.and(current)}
+    clauses.inject { |joined, current| joined.and(current) }
   end
 
   def create_single_attribute_clause(search_attribute, filter, clause_generator)

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "Search", type: :helper do
     expect(results).to include(@item_whiteboard)
   end
 
-  it "rejects sql injections as search term parameter" do 
+  it "rejects sql injections as search term parameter" do
     results = search_for_items("some-random-thing'/**/OR/**/1=1/**/OR/**/description/**/LIKE/**/'")
     expect(results).not_to include(@item_book)
     expect(results).not_to include(@item_beamer)

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -98,4 +98,11 @@ RSpec.describe "Search", type: :helper do
     expect(results).to include(@item_whiteboard)
   end
 
+  it "rejects sql injections as search term parameter" do 
+    results = search_for_items("some-random-thing'/**/OR/**/1=1/**/OR/**/description/**/LIKE/**/'")
+    expect(results).not_to include(@item_book)
+    expect(results).not_to include(@item_beamer)
+    expect(results).not_to include(@item_whiteboard)
+  end
+
 end


### PR DESCRIPTION
Fixes #169

Fixes SQL injection on search page by replacing where clauses with active records.

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
