### PR TITLE
Add default HPI group for all OIDC users

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -4,12 +4,16 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def openid_connect
     @user = User.from_omniauth(request.env["omniauth.auth"])
     if @user.persisted?
-      sign_in_and_redirect @user
-      set_flash_message(:notice, :success, kind: "OpenID Connect") if is_navigational_format?
+      success
     else
-      set_flash_message(:alert, :failure, kind: OmniAuth::Utils.camelize(failed_strategy.name), reason: failure_message)
-      redirect_to root_path
+      failure
     end
+  end
+
+  def success
+    sign_in_and_redirect @user
+    set_flash_message(:notice, :success, kind: "OpenID Connect") if is_navigational_format?
+    Group.default_hpi.members << @user
   end
 
   def failure

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -27,9 +27,17 @@ class Group < ApplicationRecord
     members - owners
   end
 
+  def self.default_hpi
+    where(system_name: :default_group_hpi).first_or_create!(name: "HPI")
+  end
+
   private
 
   def owner?
-    errors.add(:base, "Group has to have an owner") if owners.empty?
+    errors.add(:base, "User defined group has to have an owner") if owners.empty? && user_defined?
+  end
+
+  def user_defined?
+    system_name.nil?
   end
 end

--- a/db/migrate/20230117204118_create_removed_from_group_notifications.rb
+++ b/db/migrate/20230117204118_create_removed_from_group_notifications.rb
@@ -1,0 +1,9 @@
+class CreateRemovedFromGroupNotifications < ActiveRecord::Migration[7.0]
+  def change
+    create_table :removed_from_group_notifications do |t|
+      t.string :group_name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230121122621_add_system_name_to_groups.rb
+++ b/db/migrate/20230121122621_add_system_name_to_groups.rb
@@ -1,0 +1,5 @@
+class AddSystemNameToGroups < ActiveRecord::Migration[7.0]
+  def change
+    add_column :groups, :system_name, :string, { default: nil }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,8 +14,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_21_122621) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_21_122621) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -158,6 +158,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_21_122621) do
     t.index ["item_id", "user_or_group_id", "user_or_group_type"], name: "index_permission_on_item_and_user_or_group", unique: true
     t.index ["item_id"], name: "index_permissions_on_item_id"
     t.index ["user_or_group_type", "user_or_group_id"], name: "index_permissions_on_user_or_group"
+  end
+
+  create_table "removed_from_group_notifications", force: :cascade do |t|
+    t.string "group_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "return_accepted_notifications", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_17_204118) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_21_122621) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_17_204118) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
+    t.integer "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -67,6 +67,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_17_204118) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "system_name"
   end
 
   create_table "items", force: :cascade do |t|
@@ -141,7 +142,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_17_204118) do
     t.datetime "updated_at", null: false
     t.string "actable_type"
     t.integer "actable_id"
-    t.boolean "active", null: false
+    t.boolean "active", default: false, null: false
     t.boolean "unread"
     t.index ["actable_type", "actable_id"], name: "index_notifications_on_actable"
     t.index ["receiver_id"], name: "index_notifications_on_receiver_id"
@@ -157,12 +158,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_17_204118) do
     t.index ["item_id", "user_or_group_id", "user_or_group_type"], name: "index_permission_on_item_and_user_or_group", unique: true
     t.index ["item_id"], name: "index_permissions_on_item_id"
     t.index ["user_or_group_type", "user_or_group_id"], name: "index_permissions_on_user_or_group"
-  end
-
-  create_table "removed_from_group_notifications", force: :cascade do |t|
-    t.string "group_name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "return_accepted_notifications", force: :cascade do |t|

--- a/spec/features/groups/groups_spec.rb
+++ b/spec/features/groups/groups_spec.rb
@@ -145,4 +145,25 @@ RSpec.describe "Groups", type: :feature do
     expect(notification.description).to include(group.name)
   end
 
+  it "does not add normal users to the HPI group" do
+    user = create(:user)
+    sign_in user
+    expect(user.groups).not_to include(Group.default_hpi)
+  end
+
+  it "adds OIDC users to the HPI group" do
+    oidc_user = create(:peter)
+    OmniAuth.config.mock_auth[:openid_connect] = OmniAuth::AuthHash.new(
+      provider: "openid_connect",
+      uid: "peter.lustig",
+      info: {
+        email: oidc_user.email
+      }
+    )
+
+    visit new_user_session_path
+    find_by_id('openid_connect-signin').click
+    expect(oidc_user.groups).to include(Group.default_hpi)
+  end
+
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -10,9 +10,15 @@ RSpec.describe Group, type: :model do
     expect(@group).to be_valid
   end
 
-  it "is not valid without an owner" do
+  it "is not valid without an owner by default" do
     @group.owners.delete_all
     expect(@group).not_to be_valid
+  end
+
+  it "is is valid without an owner if it is not user-defined" do
+    @group.system_name = "test-group"
+    @group.owners.delete_all
+    expect(@group).to be_valid
   end
 
   it "lists owners in the list of members" do


### PR DESCRIPTION
Fixes #89 

This MR adds a crude differentiation of system groups and user-defined groups. System groups do not need any owner.  
The only system group for now is `HPI`.

Any user authenticating with OIDC is added to the `HPI` system group upon authentication. This implies that even if they leave (#286), they will be re-added on next login. 

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] ~~localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)~~ The only user-facing string is the group name `HPI`. Group names are not internationalized.
- [x] another dev reviewed and approved
- [ ] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
