### PR TITLE
Feature/ap 249 item list popularity

### DIFF
--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -15,6 +15,11 @@ module StatisticsHelper
     (item.waitlist_length + 1)) / (item.age.nonzero? or 1)
   end
 
+  def statistics_sort_items_by_popularity(items, order = :desc)
+    sorted_items = items.sort_by { |item| statistics_item_popularity(item) }
+    order == :asc ? sorted_items : sorted_items.reverse
+  end
+
   private
 
   def item_lend_events(item)

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -130,4 +130,13 @@ RSpec.describe "Search", type: :helper do
     end
   end
 
+  it "sorts items correctly by popularity descending and ascending" do
+    descending_sorted_items = helper.statistics_sort_items_by_popularity(@audited_items)
+    ascending_sorted_items = helper.statistics_sort_items_by_popularity(@audited_items, :asc)
+    descending_sorted_items.zip(ascending_sorted_items)
+                           .each_with_index do |(desc_item, asc_item), index|
+      expect(desc_item).to be == @audited_items[@audited_items.length - index - 1]
+      expect(asc_item).to be == @audited_items[index]
+    end
+  end
 end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe "Search", type: :helper do
       create(:itemAudited1),
       create(:itemAudited2)
     ]
+
+    @audited_items.each_with_index do |item, index|
+      ((index + 1) * 10).times do
+        create(:audit_event,
+               item: item,
+               event_type: :accept_lend)
+        create(:audit_event,
+               item: item,
+               event_type: :accept_return)
+      end
+    end
   end
 
   it "Searches correctly for name" do
@@ -112,16 +123,6 @@ RSpec.describe "Search", type: :helper do
   end
 
   it "puts items in the correct order when sorted by popularity" do
-    @audited_items.each_with_index do |item, index|
-      ((index + 1) * 10).times do
-        create(:audit_event,
-               item: item,
-               event_type: :accept_lend)
-        create(:audit_event,
-               item: item,
-               event_type: :accept_return)
-      end
-    end
     @audited_items.take(@audited_items.size - 1)
                   .zip(@audited_items.drop(1))
                   .collect do |first_item, second_item|


### PR DESCRIPTION
Fixes #249 

Item lists can now be sorted by popularity, ascending and descending. See [Wiki](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Statistics).

## PR checklist

- [ ] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
