### PR TITLE
Feature/ap 326 sort search results by name

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -7,6 +7,22 @@ class SearchController < ApplicationController
                       [t('views.search.order.name_a_z'), 2],
                       [t('views.search.order.name_z_a'), 3]]
 
-    @results = helpers.search_for_items(search_term)
+    order = params[:order]
+    unsorted_results = helpers.search_for_items(search_term)
+    sort_results(order, unsorted_results)
+  end
+
+  private
+
+  def sort_results(order, unsorted_results)
+    @results =
+      case order
+      when "2"
+        unsorted_results.order(name: :asc, lend_status: :asc)
+      when "3"
+        unsorted_results.order(name: :desc, lend_status: :asc)
+      else # add popularity sort here
+        unsorted_results.order(lend_status: :asc)
+      end
   end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -16,7 +16,7 @@ module SearchHelper
                                                                   :generate_equals_clause)
     numerical_attribute_clause = create_mutiple_attribute_clause(filter_numerical, relevant_numerical_attribute,
                                                                  :generate_range_clause)
-    partial_matching_clause.and(categorial_attribute_clause).and(numerical_attribute_clause).order(lend_status: :asc)
+    partial_matching_clause.and(categorial_attribute_clause).and(numerical_attribute_clause)
   end
 
   private

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -33,7 +33,7 @@
                 </button>
             </div>
             <div class="col">
-                <%= select_tag "order", options_for_select(@order_options), class: "form-select order-select" %>
+                <%= select_tag "order", options_for_select(@order_options, params[:order]), class: "form-select order-select", :onchange => "this.form.requestSubmit();" %>
             </div>
         </div>
         <%= render "filter-modal" %>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -182,4 +182,30 @@ FactoryBot.define do
     lend_status { :lent }
     owning_user { create(:user) }
   end
+
+  factory :alphabetical_first_item, class: 'Item' do
+    name { "Aalphabetical" }
+    category { "book" }
+    location { "D-Space" }
+    description { "This alphabetically the first." }
+    image { Rack::Test::UploadedFile.new('spec/testimages/test_image.png', 'image/png') }
+    price_ct { 500 }
+    rental_duration_sec { 100 }
+    rental_start { nil }
+    lend_status { :lent }
+    owning_user { create(:user) }
+  end
+
+  factory :alphabetical_second_item, class: 'Item' do
+    name { "Balphabetical" }
+    category { "book" }
+    location { "D-Space" }
+    description { "This alphabetically the second." }
+    image { Rack::Test::UploadedFile.new('spec/testimages/test_image.png', 'image/png') }
+    price_ct { 500 }
+    rental_duration_sec { 100 }
+    rental_start { nil }
+    lend_status { :lent }
+    owning_user { create(:user) }
+  end
 end

--- a/spec/features/search/search_spec.rb
+++ b/spec/features/search/search_spec.rb
@@ -6,6 +6,8 @@ describe "Search page", type: :feature do
     @item_beamer = create(:item_beamer)
     @item_whiteboard = create(:item_whiteboard)
     @item_available = create(:available_item)
+    @item_alphabetical_first = create(:alphabetical_first_item)
+    @item_alphabetical_second = create(:alphabetical_second_item)
     @item_lent = create(:lent_item)
     visit search_path
   end
@@ -69,4 +71,21 @@ describe "Search page", type: :feature do
     expect(page).to have_text(/#{@item_available.name}.*\n.*#{@item_lent.name}/)
   end
 
+  it "shows items sorted by name ascending" do
+    I18n.with_locale(:en) do
+      page.select "Name (A-Z)", from: 'order'
+      page.fill_in "search", with: "alphabetical"
+      click_button("submit")
+      expect(page).to have_text(/#{@item_alphabetical_first.name}.*\n.*#{@item_alphabetical_second.name}/)
+    end
+  end
+
+  it "shows items sorted by name descending" do
+    I18n.with_locale(:en) do
+      page.select "Name (Z-A)", from: 'order'
+      page.fill_in "search", with: "alphabetical"
+      click_button("submit")
+      expect(page).to have_text(/#{@item_alphabetical_second.name}.*\n.*#{@item_alphabetical_first.name}/)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #326

Added possibility to sort results by name asc and desc. 
Sort dropdown now always shows last sort value.

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
