### PR TITLE
feature: remove "sort-by" option from sort dropdown menu

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -22,10 +22,9 @@ class SearchController < ApplicationController
 
     @category_options = Item.select(:category).distinct.pluck(:category)
 
-    @order_options = [[t('views.search.order.default'), 0],
-                      [t('views.search.order.popularity'), 1],
-                      [t('views.search.order.name_a_z'), 2],
-                      [t('views.search.order.name_z_a'), 3]]
+    @order_options = [[t('views.search.order.popularity'), 0],
+                      [t('views.search.order.name_a_z'), 1],
+                      [t('views.search.order.name_z_a'), 2]]
   end
 
   def create_availability_filter
@@ -54,9 +53,9 @@ class SearchController < ApplicationController
   def sort_results(order, unsorted_results)
     @results =
       case order
-      when "2"
+      when "1"
         unsorted_results.order(name: :asc, lend_status: :asc)
-      when "3"
+      when "2"
         unsorted_results.order(name: :desc, lend_status: :asc)
       else # add popularity sort here
         unsorted_results.order(lend_status: :asc)

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -106,7 +106,6 @@ de:
         all: "Alle Ergebnisse"
       qr_scanner_title: "QR Scanner"
       order:
-        default: "Sortieren nach"
         popularity: "Beliebtheit"
         name_a_z: "Name (A-Z)"
         name_z_a: "Name (Z-A)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,7 +137,6 @@ en:
         all: "All"
       qr_scanner_title: "QR Scanner"
       order:
-        default: "Sort by"
         popularity: "Popularity"
         name_a_z: "Name (A-Z)"
         name_z_a: "Name (Z-A)"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,8 +14,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_21_122621) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_21_122621) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end


### PR DESCRIPTION
Fixes #357

Removed the option sort by in the sort drop down menu. This option is no longer needed since the default sort order is now by popularity (which already was an option in the drop down menu).

## PR checklist

- [ ] dev-branch has been merged into local branch to resolve conflicts
- [ ] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
