### PR TITLE
Make "Add member" button work on mobile

### DIFF
--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,12 +1,16 @@
-<div class="d-flex justify-content-between">
+<div class="">
   <h1><%= @group.name %></h1>
 
   <% if current_user.owns_group? @group %>
     <% if (User.all - @group.members).length > 0 %>
-      <%= form_with url: url_for(action: 'add_member', controller: 'groups' ), class: "d-flex gap-3" do |form| %>
-          <%= form.collection_select(:user_id, User.all - @group.members, :id, :email) %>
-          <%= form.submit t('views.groups.add_member'), class: "btn-primary"%>
+
+      <%= form_with url: url_for(action: 'add_member', controller: 'groups' ) do |form| %>
+        <div class="input-group mb-3">
+          <%= form.collection_select(:user_id, User.all - @group.members, :id, :email, {}, {:class=>"form-select"}) %>
+          <%= form.submit t('views.groups.add_member'), class: "btn btn-primary"%>
+        </div>
       <% end %>
+
     <% else %>
       <p><%= t 'views.groups.no_users_to_add' %></p>
     <% end %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,50 +1,48 @@
-<div class="">
-  <h1><%= @group.name %></h1>
+<h1><%= @group.name %></h1>
 
-  <% if current_user.owns_group? @group %>
-    <% if (User.all - @group.members).length > 0 %>
+<% if current_user.owns_group? @group %>
+  <% if (User.all - @group.members).length > 0 %>
 
-      <%= form_with url: url_for(action: 'add_member', controller: 'groups' ) do |form| %>
-        <div class="input-group mb-3">
-          <%= form.collection_select(:user_id, User.all - @group.members, :id, :email, {}, {:class=>"form-select"}) %>
-          <%= form.submit t('views.groups.add_member'), class: "btn btn-primary"%>
-        </div>
-      <% end %>
-
-    <% else %>
-      <p><%= t 'views.groups.no_users_to_add' %></p>
+    <%= form_with url: url_for(action: 'add_member', controller: 'groups') do |form| %>
+      <div class="input-group mb-3">
+        <%= form.collection_select(:user_id, User.all - @group.members, :id, :email, {}, { :class => "form-select" }) %>
+        <%= form.submit t('views.groups.add_member'), class: "btn btn-primary" %>
+      </div>
     <% end %>
+
+  <% else %>
+    <p><%= t 'views.groups.no_users_to_add' %></p>
   <% end %>
-</div>
+<% end %>
 
 
 <h2><%= t 'views.groups.owners' %></h2>
 <ul id="group-owners">
-<% @group.owners.each do |user| %>
+  <% @group.owners.each do |user| %>
     <li>
-        <%= user.name %>
-        <% if @group.owners.include?(current_user) %>
-            <%= link_to group_demote_path(@group, user), class: "badge rounded-pill text-bg-primary", data: {turbo_method: :post} do %>
-                <i class="bi bi-award-fill"></i><%= t 'views.groups.demote' %>
-            <% end %>
+      <%= user.name %>
+      <% if @group.owners.include?(current_user) %>
+        <%= link_to group_demote_path(@group, user), class: "badge rounded-pill text-bg-primary", data: { turbo_method: :post } do %>
+          <i class="bi bi-award-fill"></i><%= t 'views.groups.demote' %>
         <% end %>
+      <% end %>
     </li>
-<% end %>
+  <% end %>
 </ul>
 
 <h2><%= t 'views.groups.members' %></h2>
 <ul id="group-members">
-<% @group.members_without_ownership.each do |user| %>
+  <% @group.members_without_ownership.each do |user| %>
     <li>
-        <%= user.name %>
-        <% if @group.owners.include?(current_user) %>
-            <%= link_to group_promote_path(@group, user), class: "badge rounded-pill text-bg-primary", data: {turbo_method: :post} do %>
-                <i class="bi bi-award"></i><%= t 'views.groups.promote' %>
-            <% end %>
-        <%= link_to group_remove_path(@group, user), class: "badge rounded-pill text-bg-primary", data: {turbo_method: :post} do %>
+      <%= user.name %>
+      <% if @group.owners.include?(current_user) %>
+        <%= link_to group_promote_path(@group, user), class: "badge rounded-pill text-bg-primary", data: { turbo_method: :post } do %>
+          <i class="bi bi-award"></i><%= t 'views.groups.promote' %>
+        <% end %>
+        <%= link_to group_remove_path(@group, user), class: "badge rounded-pill text-bg-primary", data: { turbo_method: :post } do %>
           <i class="bi bi-trash"></i><%= t 'views.groups.remove' %>
         <% end %>
-        <% end %>
+      <% end %>
     </li>
-<% end %>
+  <% end %>
 </ul>


### PR DESCRIPTION
Fixes #355 

Uses Bootstrap styling and moves add member dropdown below group title on desktop and mobile. 

![image](https://user-images.githubusercontent.com/16378455/214873299-6d559ace-567f-45ae-9291-4a3ae8b9a785.png)


![image](https://user-images.githubusercontent.com/16378455/214873188-eade5345-bb7a-466a-8958-e9fc1d781146.png)


## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
