### PR TITLE
Feature: show average lend time for item

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,6 +20,11 @@ class ItemsController < ApplicationController
   # GET /items/1 or /items/1.json
   def show
     @item = Item.find(params[:id])
+
+    @avg_lend_time = helpers.statistics_item_lend_time(@item)
+    @avg_lend_time_min, @avg_lend_time_sec = @avg_lend_time.divmod(60)
+    @avg_lend_time_hour, @avg_lend_time_min = @avg_lend_time_min.divmod(60)
+    @avg_lend_time_day, @avg_lend_time_hour = @avg_lend_time_hour.divmod(24)
     return unless @item.waitlist.nil?
 
     @item.waitlist = Waitlist.new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,7 +29,7 @@ class ItemsController < ApplicationController
     @avg_lend_time_min, @avg_lend_time_sec = @avg_lend_time.divmod(60)
     @avg_lend_time_hour, @avg_lend_time_min = @avg_lend_time_min.divmod(60)
     @avg_lend_time_day, @avg_lend_time_hour = @avg_lend_time_hour.divmod(24)
-    
+
     return unless @item.waitlist.nil?
 
     @item.waitlist = Waitlist.new

--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -20,6 +20,12 @@ module StatisticsHelper
     order == :asc ? sorted_items : sorted_items.reverse
   end
 
+  def statistics_item_lend_time(item)
+    lend_events = item_lend_events(item)
+    return_events = item_return_events(item)
+    average_lend_duration(lend_events, return_events)
+  end
+
   private
 
   def item_lend_events(item)

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -213,6 +213,29 @@
             <% end %>
           <% end %>
         </p>
+
+        <% if @avg_lend_time != 0%>
+          <p class="subtitle"><%= t('views.show_item.avg_lend_time') %></p>
+          <p class="body-1">
+          <% if @avg_lend_time_day.round != 0%>
+            <%= @avg_lend_time_day.round %>
+            <%= t('amount.day', count: @avg_lend_time_day.round) %>
+          <% end %>
+          <% if @avg_lend_time_hour.round != 0%>
+            <%= @avg_lend_time_hour.round %>
+            <%= t('amount.hour', count: @avg_lend_time_hour.round) %>
+          <% end %>
+          <% if @avg_lend_time_min.round != 0%>
+            <%= @avg_lend_time_min.round %>
+            <%= t('amount.minute', count: @avg_lend_time_min.round) %>
+          <% end %>
+          <% if @avg_lend_time_sec.round != 0%>
+            <%= @avg_lend_time_sec.round %>
+            <%= t('amount.second', count: @avg_lend_time_sec.round) %>
+          <% end %>
+          </p>
+        <% end %>
+
         <div id="buttons">
           <div class="button"> <%= render "adaptive_lend_button", current_user: current_user, item: @item %> </div>
           <div class="button">

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -154,6 +154,7 @@ de:
       show_waitlist: "Warteliste zeigen"
       enter_favorites: "Auf die Merkliste gesetzt"
       leave_favorites: "Von der Merkliste entfernt"
+      avg_lend_time: "Durchschnittliche Ausleihdauer"
     edit_item:
       rental_duration_sec: "Ausleihdauer (Sekunden)"
       price_ct : "Preis in ct"
@@ -195,3 +196,16 @@ de:
   notification_mailer:
     notification:
       subject: "%{notification_name}"
+  amount:
+    second:
+      one: "Sekunde"
+      other: "Sekunden"
+    minute:
+      one: "Minute"
+      other: "Minuten"
+    hour:
+      one: "Stunde"
+      other: "Stunden"
+    day:
+      one: "Tag"
+      other: "Tage"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -184,6 +184,7 @@ en:
       show_waitlist: "Show waitlist"
       enter_favorites: "Added to favorites"
       leave_favorites: "Removed from favorites"
+      avg_lend_time: "Average lend time"
     edit_item:
       rental_duration_sec: "Rental Duration (seconds)"
       price_ct : "Price in Cent"
@@ -222,3 +223,16 @@ en:
   notification_mailer:
     notification:
       subject: "%{notification_name}"
+  amount:
+    second:
+      one: "second"
+      other: "seconds"
+    minute:
+      one: "minute"
+      other: "minutes"
+    hour:
+      one: "hour"
+      other: "hours"
+    day:
+      one: "day"
+      other: "days"

--- a/spec/features/items/show.html.erb_spec.rb
+++ b/spec/features/items/show.html.erb_spec.rb
@@ -356,4 +356,45 @@ RSpec.describe "items/show", type: :feature do
     visit item_url(item_lent)
     expect(page).to have_text I18n.t("views.show_item.less_than_months", months_amount: 6)
   end
+
+  it "shows average lend time statistic" do
+    item_with_audit = create(:itemAudited0)
+
+    create(:audit_event,
+           item: item_with_audit,
+           event_type: :accept_lend,
+           created_at: Date.jd(0))
+    create(:audit_event,
+           item: item_with_audit,
+           event_type: :accept_return,
+           created_at: Date.jd(1))
+    visit item_url(item_with_audit)
+    expect(page).to have_text I18n.t("views.show_item.avg_lend_time")
+    expect(page).to have_text "1 #{I18n.t('amount.day', count: 1)}"
+  end
+
+  it "doesn't shows average lend time statistic if it has never been lent" do
+    item_with_audit = create(:item)
+    visit item_url(item_with_audit)
+    expect(page).not_to have_text I18n.t("views.show_item.avg_lend_time")
+  end
+
+  it "shows only relevant timeunits for average lend time statistic" do
+    item_with_audit = create(:itemAudited0)
+
+    create(:audit_event,
+           item: item_with_audit,
+           event_type: :accept_lend,
+           created_at: Date.jd(0))
+    create(:audit_event,
+           item: item_with_audit,
+           event_type: :accept_return,
+           created_at: Date.jd(1))
+    visit item_url(item_with_audit)
+    expect(page).to have_text I18n.t("views.show_item.avg_lend_time")
+    expect(page).to have_text "1 #{I18n.t('amount.day', count: 1)}"
+    expect(page).not_to have_text I18n.t("amount.hour", count: 1)
+    expect(page).not_to have_text I18n.t("amount.minute", count: 1)
+    expect(page).not_to have_text I18n.t("amount.second", count: 1)
+  end
 end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -15,13 +15,15 @@ RSpec.describe "Search", type: :helper do
     ]
 
     @audited_items.each_with_index do |item, index|
-      ((index + 1) * 10).times do
+      ((index + 1) * 10).times do | i |
         create(:audit_event,
                item: item,
-               event_type: :accept_lend)
+               event_type: :accept_lend,
+               created_at: Date.jd((index + 1) * i))
         create(:audit_event,
                item: item,
-               event_type: :accept_return)
+               event_type: :accept_return,
+               created_at: Date.jd((index + 1) * i + (index+1)))
       end
     end
   end
@@ -138,5 +140,15 @@ RSpec.describe "Search", type: :helper do
       expect(desc_item).to be == @audited_items[@audited_items.length - index - 1]
       expect(asc_item).to be == @audited_items[index]
     end
+  end
+
+  it "puts calculates the average lend time correctly" do
+    calc_avg_lend_time = helper.statistics_item_lend_time(@audited_items[0])
+    expect(calc_avg_lend_time).to eq(1.day)
+  end
+
+  it "puts calculates the average lend time of a never borrowed before item correctly" do
+    calc_avg_lend_time = helper.statistics_item_lend_time(@item_book)
+    expect(calc_avg_lend_time).to eq(0.seconds)
   end
 end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Search", type: :helper do
     ]
 
     @audited_items.each_with_index do |item, index|
-      ((index + 1) * 10).times do | i |
+      ((index + 1) * 10).times do |i|
         create(:audit_event,
                item: item,
                event_type: :accept_lend,
@@ -23,7 +23,7 @@ RSpec.describe "Search", type: :helper do
         create(:audit_event,
                item: item,
                event_type: :accept_return,
-               created_at: Date.jd((index + 1) * i + (index+1)))
+               created_at: Date.jd(((index + 1) * i) + (index + 1)))
       end
     end
   end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -142,12 +142,12 @@ RSpec.describe "Search", type: :helper do
     end
   end
 
-  it "puts calculates the average lend time correctly" do
+  it "calculates the average lend time correctly" do
     calc_avg_lend_time = helper.statistics_item_lend_time(@audited_items[0])
     expect(calc_avg_lend_time).to eq(1.day)
   end
 
-  it "puts calculates the average lend time of a never borrowed before item correctly" do
+  it "calculates the average lend time of a never borrowed before item correctly" do
     calc_avg_lend_time = helper.statistics_item_lend_time(@item_book)
     expect(calc_avg_lend_time).to eq(0.seconds)
   end


### PR DESCRIPTION
Fixes #143 

This PR adds the "average lend time statistic" to the statistic model. 
You can see the average lent time on the item page (see screenshot). The time is divided into different time units (days, hours, minutes, seconds), which are only shown if needed. The item page will not show the average lending time if an item has never been lent.

![Screenshot 2023-01-28 at 11 42 11](https://user-images.githubusercontent.com/45163503/215262271-ec2bba3d-abac-4e11-8829-f626d425b4dd.png)

![Screenshot 2023-01-28 at 11 47 20](https://user-images.githubusercontent.com/45163503/215262491-74501c6f-0056-4ce7-9408-47937de87978.png)

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
