### PR TITLE
remove back button on item edit and show page

### DIFF
--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -50,10 +50,6 @@
     max-height: 25em !important;
   }
 
-  #back-button{
-    font-size: 35px;
-  }
-
   #locationIcon{
     font-size: 20px;
     vertical-align: text-top;
@@ -166,10 +162,6 @@ function readURL(input) {
 </script>
 
 <div>
-    <%= link_to @item do %>
-      <span class="material-symbols-outlined" id="back-button">chevron_left</span>
-    <% end %>
-
   <div>
   <%= form_with(model: @item) do |form| %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -54,10 +54,6 @@
         max-height: 25em !important;
     }
 
-    #back-button {
-        font-size: 35px;
-    }
-
     #locationIcon {
         font-size: 20px;
         vertical-align: text-top;
@@ -129,10 +125,6 @@
 </style>
 
 <div>
-
-  <%= link_to :back do %>
-    <span class="material-symbols-outlined" id="back-button">chevron_left</span>
-  <% end %>
   <% if !current_user.nil? && @item.users_with_ownership_permission.include?(current_user) %>
     <%= link_to edit_item_url(@item) do %>
       <span class="material-symbols-outlined editItemIcon" id="notFilledEditItemIcon">edit</span>


### PR DESCRIPTION
Fixes #217 <n>

The back button was removed, because it had no functionality.

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
