### PR TITLE
Use regular URL instead of data URL #speed

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,7 +9,7 @@ require "stringio"
 # rubocop:disable Metrics/PerceivedComplexity
 
 class ItemsController < ApplicationController
-  before_action :set_item, except: %i[ index new create image ]
+  before_action :set_item, except: %i[ index new create ]
 
   before_action :set_lendable, only: %i[ show ]
   before_action :check_lendable, only: %i[ request_lend add_to_waitlist ]

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,7 +10,7 @@ require "stringio"
 
 class ItemsController < ApplicationController
   before_action :set_item,
-                only: %i[ show edit update destroy request_return accept_return request_lend]
+                only: %i[ show edit update destroy request_return accept_return request_lend image]
 
   # GET /items or /items.json
   def index
@@ -238,6 +238,10 @@ class ItemsController < ApplicationController
     pdf = Prawn::Document.new(page_size: "A4")
     pdf.image dummy_png_file, position: :center
     send_data pdf.render, disposition: "attachment", type: "application/pdf"
+  end
+
+  def image
+    send_data @item.image
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -50,7 +50,7 @@ class Item < ApplicationRecord
   end
 
   def image_url
-    "data:application/octet-stream;base64,#{Base64.strict_encode64(image)}"
+    "/items/#{id}/image"
   end
 
   def set_status_available

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,8 @@
 # class of a basic item.
 # rubocop:disable Metrics/ClassLength
 class Item < ApplicationRecord
+  include Rails.application.routes.url_helpers
+
   has_one :waitlist, dependent: :destroy
   has_many :audit_events, dependent: :destroy
   has_many :lend_request_notifications, dependent: :destroy
@@ -50,7 +52,7 @@ class Item < ApplicationRecord
   end
 
   def image_url
-    "/items/#{id}/image"
+    item_image_path(id: id)
   end
 
   def set_status_available

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
 
   resources :items
+  get 'items/:id/image', to: 'items#image', as: 'item_image'
   get 'dashboard', to: 'dashboard#index'
   get 'search', to: 'search#index'
   get 'notifications', to: 'notifications#index'

--- a/spec/features/items/show.html.erb_spec.rb
+++ b/spec/features/items/show.html.erb_spec.rb
@@ -91,12 +91,6 @@ RSpec.describe "items/show", type: :feature do
     expect(page).to have_css("main img")
   end
 
-  it "renders an image with a data url" do
-    sign_in user
-    visit item_path(item)
-    expect(page).to have_css('main img[src^="data:"]')
-  end
-
   it "has lend button when item is available and not owner of item" do
     sign_in user
     visit item_path(item)


### PR DESCRIPTION
Fixes #364 

The images do not block rendering of the rest of the page.

[Peek 2023-01-30 16-15.webm](https://user-images.githubusercontent.com/25486288/215517048-c469e869-f149-4113-a1b5-ce759445a188.webm)

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] tests and linter have passed AFTER local merge
- [x] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [x] another dev reviewed and approved
- [ ] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
