### PR TITLE
Bug/tf+ 95 items with negative values

### DIFF
--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -240,10 +240,10 @@ function readURL(input) {
             </div>
 
             <p class="subtitle"><%= t('views.edit_item.price_ct')%></p>
-            <%= form.number_field :price_ct, class: "borderedInput body1" %>
+            <%= form.number_field :price_ct, min: 0, class: "borderedInput body1", oninput: "validity.valid||(value='');" %>
 
             <p class="subtitle"><%= t('views.edit_item.rental_duration_sec')%>*</p>
-            <%= form.number_field :rental_duration_sec, class: "borderedInput body1" %>
+            <%= form.number_field :rental_duration_sec, min: 0, class: "borderedInput body1", oninput: "validity.valid||(value='');" %>
 
             <p class="subtitle"><%= t('views.edit_item.return_checklist')%></p>
             <%= form.text_area :return_checklist, class: "borderedInput body1" %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -247,10 +247,10 @@
             </div>
 
             <p class="subtitle"><%= t('views.edit_item.price_ct') %></p>
-            <%= form.number_field :price_ct, class: "borderedInput body1" %>
+            <%= form.number_field :price_ct, min: 0, class: "borderedInput body1", oninput: "validity.valid||(value='');" %>
 
             <p class="subtitle"><%= t('views.edit_item.rental_duration_sec') %>*</p>
-            <%= form.number_field :rental_duration_sec, class: "borderedInput body1" %>
+            <%= form.number_field :rental_duration_sec, min: 0, class: "borderedInput body1", oninput: "validity.valid||(value='');" %>
 
             <p class="subtitle"><%= t('views.edit_item.return_checklist') %></p>
             <%= form.text_area :return_checklist, class: "borderedInput body1" %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -63,7 +63,7 @@ de:
       timestamp_Sunday: "Sonntag"
       lending_accepted:
         title: "Ausleihanfrage angenommen"
-        description: "%{owner} hat deine Anfrage zu %{item} angenommen. Du kannst es jetzt abholen"
+        description: "%{owner} hat deine Anfrage zu %{item} angenommen. Du kannst es jetzt abholen."
       lending_denied:
         title: "Ausleihanfrage abgelehnt"
         description: "%{owner} hat deine Anfrage zu %{item} abgelehnt."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,7 +94,7 @@ en:
       timestamp_Sunday: "Sunday"
       lending_accepted:
         title: "Lending Accepted"
-        description: "%{owner} has accepted your request to borrow %{item}. You can pick it up now"
+        description: "%{owner} has accepted your request to borrow %{item}. You can pick it up now."
       lending_denied:
         title: "Lending Denied"
         description: "%{owner} has denied your request to borrow %{item}."


### PR DESCRIPTION
Fixes #95 

Prevents users from typing negative values for `price` and `rental_duration`.

## PR checklist

- [ ] dev-branch has been merged into local branch to resolve conflicts
- [ ] tests and linter have passed AFTER local merge
- [ ] localization is supported [(Guide)](https://github.com/hpi-swt2/bookkeeper-portal-blue/wiki/Internationalization-guide)
- [ ] another dev reviewed and approved
- [ ] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
